### PR TITLE
Feature/users follow

### DIFF
--- a/back/app/controllers/api/v1/user/users_controller.rb
+++ b/back/app/controllers/api/v1/user/users_controller.rb
@@ -69,4 +69,46 @@ class Api::V1::User::UsersController < Api::V1::User::Base
     render json: data
   end
   
+  def follows
+    user = User.find(params[:id])
+    users = user.followings
+    page_length = users.page(1).per(10).total_pages
+    usersArray = []
+    users.each do |user|
+      userObj = {}
+      userObj["id"] = user.id
+      userObj["name"] = user.name
+      userObj["nickname"] = user.nickname
+      userObj["introduction"] = user.introduction
+      userObj["image"] = user.image
+      usersArray.push(userObj)
+    end
+    data = {
+      'follows': usersArray,
+      'page_length': page_length
+    }
+    render json: data
+  end
+
+  def followers
+    user = User.find(params[:id])
+    users = user.followers
+    page_length = users.page(1).per(10).total_pages
+    usersArray = []
+    users.each do |user|
+      userObj = {}
+      userObj["id"] = user.id
+      userObj["name"] = user.name
+      userObj["nickname"] = user.nickname
+      userObj["introduction"] = user.introduction
+      userObj["image"] = user.image
+      usersArray.push(userObj)
+    end
+    data = {
+      'followers': usersArray,
+      'page_length': page_length
+    }
+    render json: data
+  end
+
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
           member do
             get :posts
             get :favorite_posts
+            get :follows
+            get :followers
           end
         end
         resources :posts do

--- a/front/front-app/src/assets/style/chakraStyles.js
+++ b/front/front-app/src/assets/style/chakraStyles.js
@@ -72,7 +72,7 @@ export const UsersPageButton = (props) => {
     <Button
       colorScheme="teal"
       variant="ghost"
-      fontSize={{ base: "xs", md: "lg" }}
+      fontSize={{ base: "5px", md: "lg" }}
       {...props}
     />
   );

--- a/front/front-app/src/components/atoms/button/BooleanButton.jsx
+++ b/front/front-app/src/components/atoms/button/BooleanButton.jsx
@@ -6,8 +6,8 @@ export const BooleanButton = (props) => {
     <Button
       onClick={onClick} 
       colorScheme={colorBoolean? "blue" : "gray" }
-      fontSize={{base: "11px", md: "15px"}}
-      w={{base: "60px", md: "85px"}}
+      fontSize={{base: "8px", md: "15px"}}
+      w={{base: "100px", md: "130px"}}
       h={{base: "30px", md: "45px"}}
       outline="none"
       disabled={loadingState}

--- a/front/front-app/src/components/organisms/follow/FollowLayout.jsx
+++ b/front/front-app/src/components/organisms/follow/FollowLayout.jsx
@@ -1,0 +1,55 @@
+import React, { useCallback } from 'react'
+import {push} from 'connected-react-router';
+import { Box, Center } from '@chakra-ui/layout';
+import { Spinner } from "@chakra-ui/spinner";
+import useLoadingState from '../../../hooks/useLoadingState';
+import usePagination from '../../../hooks/usePagination';
+import DefaultPagination from '../../molecules/DefaultPagination';
+import useReturnTop from '../../../hooks/useReturnTop';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router';
+import UsersCard from '../users/UsersCard';
+
+export const FollowLayout = (props) => {
+  const {users} = props
+  const userId = useParams();
+  const dispatch = useDispatch()
+  const loadingState = useLoadingState()
+  const returnTop = useReturnTop()
+  const {queryPage, sumPage } = usePagination()
+
+
+  const changeCurrentPage = useCallback((e, page) => {
+    dispatch(push(`/users/${userId.id}/follows?page=${page}`))
+    returnTop();
+  },[dispatch, returnTop, userId.id])
+
+  return(
+    <>
+    { loadingState? (
+      <Center w={{base: "50vh", md: "100vh"}}>
+        <Spinner/>
+      </Center>
+    ): (
+      <>
+        {users.length > 0 && (
+          <Box mr="2" ml="2" mb="2">
+            {
+              users.map(user =>(
+                <UsersCard key={user.id} user={user}/>
+              ))
+            }
+          </Box>
+        )}
+        <DefaultPagination 
+          count={sumPage}
+          onChange={changeCurrentPage}
+          page={queryPage}
+        />
+      </>
+    )}
+    </>
+  )
+}
+
+export default FollowLayout;

--- a/front/front-app/src/components/organisms/post/PostShowCard.jsx
+++ b/front/front-app/src/components/organisms/post/PostShowCard.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { push } from 'connected-react-router'
 import CreateIcon from '@material-ui/icons/Create';
 import ThumbUpIcon from '@material-ui/icons/ThumbUp';
+import ThumbsUpDownIcon from '@material-ui/icons/ThumbsUpDown';
 import defaultImage from '../../../assets/img/defaultImage.jpeg'
 import defaultUserIcon from '../../../assets/img/defaultUserIcon.jpeg'
 import { DefaultFlex, 
@@ -90,8 +91,19 @@ export const PostShowCard = (props)=> {
             colorBoolean={favorite}
             loadingState={loadingState}
           >
-            Good!
-            <ThumbUpIcon style={{fontSize: 13, marginLeft: 5}}/>
+            {
+              favorite ? (
+                <>
+                  高評価済
+                  <ThumbUpIcon style={{fontSize: 13, marginLeft: 5}}/>
+                </>
+              ) : (
+                <>
+                  高評価する
+                  <ThumbsUpDownIcon style={{fontSize: 13, marginLeft: 5}}/>
+                </>
+              )
+            }
           </BooleanButton>
           { 
             user_id === currentUserId ? (

--- a/front/front-app/src/components/organisms/users/UsersShowCard.jsx
+++ b/front/front-app/src/components/organisms/users/UsersShowCard.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router'
 import { Divider } from '@chakra-ui/react'
 import { useDispatch, useSelector } from 'react-redux'
 import GroupAddIcon from '@material-ui/icons/GroupAdd';
+import CheckIcon from '@material-ui/icons/Check';
 
 import { showUsers } from '../../../reducks/users/operations'
 import { confirmFollowing, createFollowing, destroyFollowing } from '../../../reducks/follow/operations'
@@ -60,10 +61,11 @@ export const UsersShowCard = () => {
         w={{base: "full", xl: "75%"}}
         m={{base: "auto", md: "2"}}
         >
-          <Flex>
+          <Flex flexDirection={{base: "column", md: "unset"}}>
             <DefaultTitleText
               as="h2"
               mr="5"
+              mb={{base: "3", md: "0"}}
             >
               {nickname}
             </DefaultTitleText>
@@ -74,8 +76,19 @@ export const UsersShowCard = () => {
                 colorBoolean={follow}
                 loadingState={loadingState}
               >
-                Follow
-                <GroupAddIcon style={{fontSize: 14, marginLeft: 5}}/>
+                {
+                  follow ? (
+                    <>
+                      フォロー中
+                      <CheckIcon style={{fontSize: 14, marginLeft: 5}}/>
+                    </>
+                  ) : (
+                    <>
+                      フォローする
+                      <GroupAddIcon style={{fontSize: 14, marginLeft: 5}}/>
+                    </>
+                  )
+                }
               </BooleanButton>
               ) : null
             }

--- a/front/front-app/src/components/pages/mypage/Followers.jsx
+++ b/front/front-app/src/components/pages/mypage/Followers.jsx
@@ -18,8 +18,8 @@ export const Followers = () => {
   const { sumPage, setSumPage, queryPage } = usePagination()
 
   useEffect(()=> {
-    dispatch(getMyFollowers(setSumPage))
-  },[dispatch, setSumPage])
+    dispatch(getMyFollowers(queryPage, setSumPage))
+  },[dispatch, queryPage, setSumPage])
 
   const follows = useSelector(state => state.users.list)
 

--- a/front/front-app/src/components/pages/mypage/Followers.jsx
+++ b/front/front-app/src/components/pages/mypage/Followers.jsx
@@ -1,65 +1,28 @@
 import { useDispatch, useSelector } from "react-redux";
-import { Spinner } from "@chakra-ui/spinner";
-import { Box, Center } from '@chakra-ui/layout';
-import { push } from "connected-react-router";
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import usePagination from "../../../hooks/usePagination";
-import useLoadingState from "../../../hooks/useLoadingState";
-import UsersCard from "../../organisms/users/UsersCard";
-import DefaultPagination from "../../molecules/DefaultPagination";
-import useReturnTop from "../../../hooks/useReturnTop";
 import { DefaultBox, DefaultTitleText } from "../../../assets/style/chakraStyles";
 import { getMyFollowers } from "../../../reducks/users/operations";
+import FollowLayout from "../../organisms/follow/FollowLayout";
 
 export const Followers = () => {
-  const loadingState = useLoadingState()
   const dispatch = useDispatch()
-  const returnTop = useReturnTop()
-  const { sumPage, setSumPage, queryPage } = usePagination()
+  const { setSumPage, queryPage } = usePagination()
 
   useEffect(()=> {
     dispatch(getMyFollowers(queryPage, setSumPage))
   },[dispatch, queryPage, setSumPage])
 
-  const follows = useSelector(state => state.users.list)
-
-
-  const changeCurrentPage = useCallback((e, page) =>{
-    dispatch(push(`/mypage/follows?page=${page}`))
-    returnTop()
-  },[dispatch, returnTop])
+  const followers = useSelector(state => state.users.list)
 
   return(
     <>
-    {
-      loadingState? (
-        <Center  h="100vh" w={{base: "50vh", md: "100vh"}}>
-          <Spinner/>
-        </Center>
-      ):(
-        <>
-          <DefaultBox mb="5">
-            <DefaultTitleText>
-              フォロワー一覧
-            </DefaultTitleText>
-          </DefaultBox>
-          {follows.length > 0 && (
-            <Box mr="2" ml="2" mb="2">
-              {
-                follows.map(follow =>(
-                  <UsersCard key={follow.id} user={follow}/>
-                ))
-              }
-            </Box>
-          )}
-          <DefaultPagination 
-            count={sumPage}
-            onChange={changeCurrentPage}
-            page={queryPage}
-          />
-        </>
-      )
-    }
+      <DefaultBox mb="5">
+        <DefaultTitleText>
+          フォロワー一覧
+        </DefaultTitleText>
+      </DefaultBox>
+    <FollowLayout users={followers}/>
   </>
   )
 }

--- a/front/front-app/src/components/pages/mypage/Follows.jsx
+++ b/front/front-app/src/components/pages/mypage/Follows.jsx
@@ -18,8 +18,8 @@ export const Follows = () => {
   const { sumPage, setSumPage, queryPage } = usePagination()
 
   useEffect(()=> {
-    dispatch(getMyFollows(setSumPage))
-  },[dispatch, setSumPage])
+    dispatch(getMyFollows(queryPage, setSumPage))
+  },[dispatch, queryPage, setSumPage])
 
   const follows = useSelector(state => state.users.list)
 

--- a/front/front-app/src/components/pages/mypage/Follows.jsx
+++ b/front/front-app/src/components/pages/mypage/Follows.jsx
@@ -1,21 +1,13 @@
 import { useDispatch, useSelector } from "react-redux";
-import { Spinner } from "@chakra-ui/spinner";
-import { Box, Center } from '@chakra-ui/layout';
-import { push } from "connected-react-router";
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import usePagination from "../../../hooks/usePagination";
-import useLoadingState from "../../../hooks/useLoadingState";
-import UsersCard from "../../organisms/users/UsersCard";
-import DefaultPagination from "../../molecules/DefaultPagination";
-import useReturnTop from "../../../hooks/useReturnTop";
 import { DefaultBox, DefaultTitleText } from "../../../assets/style/chakraStyles";
 import { getMyFollows } from "../../../reducks/users/operations";
+import FollowLayout from "../../organisms/follow/FollowLayout";
 
 export const Follows = () => {
-  const loadingState = useLoadingState()
   const dispatch = useDispatch()
-  const returnTop = useReturnTop()
-  const { sumPage, setSumPage, queryPage } = usePagination()
+  const { setSumPage, queryPage } = usePagination()
 
   useEffect(()=> {
     dispatch(getMyFollows(queryPage, setSumPage))
@@ -23,44 +15,15 @@ export const Follows = () => {
 
   const follows = useSelector(state => state.users.list)
 
-
-  const changeCurrentPage = useCallback((e, page) =>{
-    dispatch(push(`/mypage/follows?page=${page}`))
-    returnTop()
-  },[dispatch, returnTop])
-
   return(
     <>
-    {
-      loadingState? (
-        <Center  h="100vh" w={{base: "50vh", md: "100vh"}}>
-          <Spinner/>
-        </Center>
-      ):(
-        <>
-          <DefaultBox mb="5">
-            <DefaultTitleText>
-              フォロー一覧
-            </DefaultTitleText>
-          </DefaultBox>
-          {follows.length > 0 && (
-            <Box mr="2" ml="2" mb="2">
-              {
-                follows.map(follow =>(
-                  <UsersCard key={follow.id} user={follow}/>
-                ))
-              }
-            </Box>
-          )}
-          <DefaultPagination 
-            count={sumPage}
-            onChange={changeCurrentPage}
-            page={queryPage}
-          />
-        </>
-      )
-    }
-  </>
+      <DefaultBox mb="5">
+        <DefaultTitleText>
+          フォロー一覧
+        </DefaultTitleText>
+      </DefaultBox>
+      <FollowLayout users={follows}/>
+    </>
   )
 }
 

--- a/front/front-app/src/components/pages/users/UsersFollowers.jsx
+++ b/front/front-app/src/components/pages/users/UsersFollowers.jsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useEffect } from 'react'
+import {push} from 'connected-react-router';
+import { Box, Center } from '@chakra-ui/layout';
+import { Spinner } from "@chakra-ui/spinner";
+import useLoadingState from '../../../hooks/useLoadingState';
+import usePagination from '../../../hooks/usePagination';
+import DefaultPagination from '../../molecules/DefaultPagination';
+import useReturnTop from '../../../hooks/useReturnTop';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import { getUsersFollowers } from '../../../reducks/users/operations';
+import UsersCard from '../../organisms/users/UsersCard';
+
+export const UsersFollowers = () => {
+  const userId = useParams();
+  const dispatch = useDispatch()
+  const loadingState = useLoadingState()
+  const returnTop = useReturnTop()
+  const {queryPage, sumPage, setSumPage} = usePagination()
+
+  useEffect(()=> {
+    dispatch(getUsersFollowers(userId, queryPage, setSumPage))
+  },[dispatch, userId, queryPage, setSumPage])
+
+  const followers = useSelector(state => state.users.list)
+
+  const changeCurrentPage = useCallback((e, page) => {
+    dispatch(push(`/users/${userId.id}/followers?page=${page}`))
+    returnTop();
+  },[dispatch, returnTop, userId.id])
+
+  return(
+    <>
+    { loadingState? (
+      <Center w={{base: "50vh", md: "100vh"}}>
+        <Spinner/>
+      </Center>
+    ): (
+      <>
+        {followers.length > 0 && (
+          <Box mr="2" ml="2" mb="2">
+            {
+              followers.map(follower =>(
+                <UsersCard key={follower.id} user={follower}/>
+              ))
+            }
+          </Box>
+        )}
+        <DefaultPagination 
+          count={sumPage}
+          onChange={changeCurrentPage}
+          page={queryPage}
+        />
+      </>
+    )}
+    </>
+  )
+}
+
+export default UsersFollowers;

--- a/front/front-app/src/components/pages/users/UsersFollowers.jsx
+++ b/front/front-app/src/components/pages/users/UsersFollowers.jsx
@@ -1,22 +1,14 @@
-import React, { useCallback, useEffect } from 'react'
-import {push} from 'connected-react-router';
-import { Box, Center } from '@chakra-ui/layout';
-import { Spinner } from "@chakra-ui/spinner";
-import useLoadingState from '../../../hooks/useLoadingState';
+import React, { useEffect } from 'react'
 import usePagination from '../../../hooks/usePagination';
-import DefaultPagination from '../../molecules/DefaultPagination';
-import useReturnTop from '../../../hooks/useReturnTop';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router';
 import { getUsersFollowers } from '../../../reducks/users/operations';
-import UsersCard from '../../organisms/users/UsersCard';
+import FollowLayout from '../../organisms/follow/FollowLayout';
 
 export const UsersFollowers = () => {
   const userId = useParams();
   const dispatch = useDispatch()
-  const loadingState = useLoadingState()
-  const returnTop = useReturnTop()
-  const {queryPage, sumPage, setSumPage} = usePagination()
+  const {queryPage, setSumPage} = usePagination()
 
   useEffect(()=> {
     dispatch(getUsersFollowers(userId, queryPage, setSumPage))
@@ -24,36 +16,8 @@ export const UsersFollowers = () => {
 
   const followers = useSelector(state => state.users.list)
 
-  const changeCurrentPage = useCallback((e, page) => {
-    dispatch(push(`/users/${userId.id}/followers?page=${page}`))
-    returnTop();
-  },[dispatch, returnTop, userId.id])
-
   return(
-    <>
-    { loadingState? (
-      <Center w={{base: "50vh", md: "100vh"}}>
-        <Spinner/>
-      </Center>
-    ): (
-      <>
-        {followers.length > 0 && (
-          <Box mr="2" ml="2" mb="2">
-            {
-              followers.map(follower =>(
-                <UsersCard key={follower.id} user={follower}/>
-              ))
-            }
-          </Box>
-        )}
-        <DefaultPagination 
-          count={sumPage}
-          onChange={changeCurrentPage}
-          page={queryPage}
-        />
-      </>
-    )}
-    </>
+    <FollowLayout users={followers}/>
   )
 }
 

--- a/front/front-app/src/components/pages/users/UsersFollows.jsx
+++ b/front/front-app/src/components/pages/users/UsersFollows.jsx
@@ -1,22 +1,14 @@
-import React, { useCallback, useEffect } from 'react'
-import {push} from 'connected-react-router';
-import { Box, Center } from '@chakra-ui/layout';
-import { Spinner } from "@chakra-ui/spinner";
-import useLoadingState from '../../../hooks/useLoadingState';
+import React, { useEffect } from 'react'
 import usePagination from '../../../hooks/usePagination';
-import DefaultPagination from '../../molecules/DefaultPagination';
-import useReturnTop from '../../../hooks/useReturnTop';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router';
 import { getUsersFollows } from '../../../reducks/users/operations';
-import UsersCard from '../../organisms/users/UsersCard';
+import FollowLayout from '../../organisms/follow/FollowLayout';
 
 export const UsersFollows = () => {
   const userId = useParams();
   const dispatch = useDispatch()
-  const loadingState = useLoadingState()
-  const returnTop = useReturnTop()
-  const {queryPage, sumPage, setSumPage} = usePagination()
+  const {queryPage, setSumPage} = usePagination()
 
   useEffect(()=> {
     dispatch(getUsersFollows(userId, queryPage, setSumPage))
@@ -24,36 +16,8 @@ export const UsersFollows = () => {
 
   const follows = useSelector(state => state.users.list)
 
-  const changeCurrentPage = useCallback((e, page) => {
-    dispatch(push(`/users/${userId.id}/follows?page=${page}`))
-    returnTop();
-  },[dispatch, returnTop, userId.id])
-
   return(
-    <>
-    { loadingState? (
-      <Center w={{base: "50vh", md: "100vh"}}>
-        <Spinner/>
-      </Center>
-    ): (
-      <>
-        {follows.length > 0 && (
-          <Box mr="2" ml="2" mb="2">
-            {
-              follows.map(follow =>(
-                <UsersCard key={follow.id} user={follow}/>
-              ))
-            }
-          </Box>
-        )}
-        <DefaultPagination 
-          count={sumPage}
-          onChange={changeCurrentPage}
-          page={queryPage}
-        />
-      </>
-    )}
-    </>
+    <FollowLayout users={follows} />
   )
 }
 

--- a/front/front-app/src/components/pages/users/UsersFollows.jsx
+++ b/front/front-app/src/components/pages/users/UsersFollows.jsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useEffect } from 'react'
+import {push} from 'connected-react-router';
+import { Box, Center } from '@chakra-ui/layout';
+import { Spinner } from "@chakra-ui/spinner";
+import useLoadingState from '../../../hooks/useLoadingState';
+import usePagination from '../../../hooks/usePagination';
+import DefaultPagination from '../../molecules/DefaultPagination';
+import useReturnTop from '../../../hooks/useReturnTop';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import { getUsersFollows } from '../../../reducks/users/operations';
+import UsersCard from '../../organisms/users/UsersCard';
+
+export const UsersFollows = () => {
+  const userId = useParams();
+  const dispatch = useDispatch()
+  const loadingState = useLoadingState()
+  const returnTop = useReturnTop()
+  const {queryPage, sumPage, setSumPage} = usePagination()
+
+  useEffect(()=> {
+    dispatch(getUsersFollows(userId, queryPage, setSumPage))
+  },[dispatch, userId, queryPage, setSumPage])
+
+  const follows = useSelector(state => state.users.list)
+
+  const changeCurrentPage = useCallback((e, page) => {
+    dispatch(push(`/users/${userId.id}/follows?page=${page}`))
+    returnTop();
+  },[dispatch, returnTop, userId.id])
+
+  return(
+    <>
+    { loadingState? (
+      <Center w={{base: "50vh", md: "100vh"}}>
+        <Spinner/>
+      </Center>
+    ): (
+      <>
+        {follows.length > 0 && (
+          <Box mr="2" ml="2" mb="2">
+            {
+              follows.map(follow =>(
+                <UsersCard key={follow.id} user={follow}/>
+              ))
+            }
+          </Box>
+        )}
+        <DefaultPagination 
+          count={sumPage}
+          onChange={changeCurrentPage}
+          page={queryPage}
+        />
+      </>
+    )}
+    </>
+  )
+}
+
+export default UsersFollows;

--- a/front/front-app/src/components/pages/users/UsersInfo.jsx
+++ b/front/front-app/src/components/pages/users/UsersInfo.jsx
@@ -10,6 +10,8 @@ import UsersFavoritePosts from "./UsersFavoritePosts";
 import { push } from "connected-react-router";
 import useReturnTop from "../../../hooks/useReturnTop";
 import { nowLoadingAction } from "../../../reducks/loading/actions";
+import UsersFollows from "./UsersFollows";
+import UsersFollowers from "./UsersFollowers";
 
 export const UsersInfo = () => {
   const userId = useParams();
@@ -27,6 +29,18 @@ export const UsersInfo = () => {
     dispatch(nowLoadingAction(true));
     returnTop();
   },[dispatch, returnTop, userId.id])
+
+  const toUsersFollows = useCallback(()=> {
+    dispatch(push(`/users/${userId.id}/follows`))
+    dispatch(nowLoadingAction(true));
+    returnTop();
+  },[dispatch, returnTop, userId])
+
+  const toUsersFollowers = useCallback(()=> {
+    dispatch(push(`/users/${userId.id}/followers`))
+    dispatch(nowLoadingAction(true));
+    returnTop();
+  },[dispatch, returnTop, userId])
   
   return(
     <Box>
@@ -47,10 +61,22 @@ export const UsersInfo = () => {
           >
             高評価記事
           </UsersPageButton>
+          <UsersPageButton
+            onClick={toUsersFollows}
+          >
+            フォロー
+          </UsersPageButton>
+          <UsersPageButton
+            onClick={toUsersFollowers}
+          >
+            フォロワー
+          </UsersPageButton>
       </DefaultFlex>
       <Switch>
         <Route exact path={"/users/:id"} component={UsersPosts}/>
-        <Route exact path={"/users/:id/favoritePosts"} component={UsersFavoritePosts}/>
+        <Route path={"/users/:id/favoritePosts"} component={UsersFavoritePosts}/>
+        <Route path={"/users/:id/follows"} component={UsersFollows}/>
+        <Route path={"/users/:id/followers"} component={UsersFollowers}/>
       </Switch>
     </Box>
   )

--- a/front/front-app/src/reducks/favorite/operations.js
+++ b/front/front-app/src/reducks/favorite/operations.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { nowLoadingAction } from "../loading/actions";
 import {
   confirmFavoritedAction,
   createFavoriteAction,
@@ -31,7 +30,6 @@ export const confirmFavorited = (postId) => {
 
 export const createFavorite = (postId, currentUserId) => {
   return async (dispatch) => {
-    dispatch(nowLoadingAction(true));
     axios
       .post(
         `http://localhost:3001/api/v1/user/posts/${postId.id}/favorites`,
@@ -56,16 +54,12 @@ export const createFavorite = (postId, currentUserId) => {
       })
       .catch((error) => {
         console.log("error res:", error);
-      })
-      .finally(() => {
-        dispatch(nowLoadingAction(false));
       });
   };
 };
 
 export const destroyFavorite = (postId) => {
   return async (dispatch) => {
-    dispatch(nowLoadingAction(true));
     axios
       .delete(
         `http://localhost:3001/api/v1/user/posts/${postId.id}/favorites`,
@@ -83,9 +77,6 @@ export const destroyFavorite = (postId) => {
       })
       .catch((error) => {
         console.log("error res:", error);
-      })
-      .finally(() => {
-        dispatch(nowLoadingAction(false));
       });
   };
 };

--- a/front/front-app/src/reducks/follow/operations.js
+++ b/front/front-app/src/reducks/follow/operations.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { nowLoadingAction } from "../loading/actions";
 import {
   confirmFollowingAction,
   createFollowingAction,
@@ -8,7 +7,6 @@ import {
 
 export const confirmFollowing = (userId) => {
   return async (dispatch) => {
-    dispatch(nowLoadingAction(true));
     axios
       .post(
         "http://localhost:3001/api/v1/user/accounts/relationships/following_by",
@@ -27,16 +25,12 @@ export const confirmFollowing = (userId) => {
       })
       .catch((error) => {
         console.log("error res:", error);
-      })
-      .finally(() => {
-        dispatch(nowLoadingAction(false));
       });
   };
 };
 
 export const createFollowing = (userId) => {
   return async (dispatch) => {
-    dispatch(nowLoadingAction(true));
     axios
       .post(
         "http://localhost:3001/api/v1/user/accounts/relationships",
@@ -55,16 +49,12 @@ export const createFollowing = (userId) => {
       })
       .catch((error) => {
         console.log("error res:", error);
-      })
-      .finally(() => {
-        dispatch(nowLoadingAction(false));
       });
   };
 };
 
 export const destroyFollowing = (userId) => {
   return async (dispatch) => {
-    dispatch(nowLoadingAction(true));
     axios
       .patch(
         "http://localhost:3001/api/v1/user/accounts/relationships",
@@ -83,9 +73,6 @@ export const destroyFollowing = (userId) => {
       })
       .catch((error) => {
         console.log("error res:", error);
-      })
-      .finally(() => {
-        dispatch(nowLoadingAction(false));
       });
   };
 };

--- a/front/front-app/src/reducks/users/operations.js
+++ b/front/front-app/src/reducks/users/operations.js
@@ -26,13 +26,16 @@ export const showUsers = (userId) => {
   };
 };
 
-export const getMyFollows = (setSumPage) => {
+export const getMyFollows = (queryPage, setSumPage) => {
   return async (dispatch) => {
     dispatch(nowLoadingAction(true));
     axios
-      .get("http://localhost:3001/api/v1/user/accounts/follows", {
-        withCredentials: true,
-      })
+      .get(
+        `http://localhost:3001/api/v1/user/accounts/follows/?page=${queryPage}`,
+        {
+          withCredentials: true,
+        }
+      )
       .then((response) => {
         const follows = response.data.follows;
         dispatch(getUsersAction(follows));
@@ -49,13 +52,68 @@ export const getMyFollows = (setSumPage) => {
   };
 };
 
-export const getMyFollowers = (setSumPage) => {
+export const getMyFollowers = (queryPage, setSumPage) => {
   return async (dispatch) => {
     dispatch(nowLoadingAction(true));
     axios
-      .get("http://localhost:3001/api/v1/user/accounts/followers", {
-        withCredentials: true,
+      .get(
+        `http://localhost:3001/api/v1/user/accounts/followers/?page=${queryPage}`,
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        const followers = response.data.followers;
+        dispatch(getUsersAction(followers));
+        setSumPage(response.data.page_length);
       })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+      .finally(() => {
+        setTimeout(() => {
+          dispatch(nowLoadingAction(false));
+        }, 800);
+      });
+  };
+};
+
+export const getUsersFollows = (userId, queryPage, setSumPage) => {
+  return async (dispatch) => {
+    dispatch(nowLoadingAction(true));
+    axios
+      .get(
+        `http://localhost:3001/api/v1/user/users/${userId.id}/follows/?page=${queryPage}`,
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        const follows = response.data.follows;
+        dispatch(getUsersAction(follows));
+        setSumPage(response.data.page_length);
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+      .finally(() => {
+        setTimeout(() => {
+          dispatch(nowLoadingAction(false));
+        }, 800);
+      });
+  };
+};
+
+export const getUsersFollowers = (userId, queryPage, setSumPage) => {
+  return async (dispatch) => {
+    dispatch(nowLoadingAction(true));
+    axios
+      .get(
+        `http://localhost:3001/api/v1/user/users/${userId.id}/followers/?page=${queryPage}`,
+        {
+          withCredentials: true,
+        }
+      )
       .then((response) => {
         const followers = response.data.followers;
         dispatch(getUsersAction(followers));


### PR DESCRIPTION
## 他のユーザー詳細画面にフォロー、フォロワーリストを追記

### 変更概要
-  他のユーザー詳細画面にフォロー、フォロワーリストを追記

### 変更詳細
ユーザー詳細画面(/users/:id)に「フォロー」、「フォロワー」のリンクを設置。
そのユーザーのフォロー関係を確認可能

### 動作環境

確認される不具合はございません。

### 主な変更点
`reducks/users/operations`にフォロー、フォロワーリストを取得する関数を追加
`components/pages/users`にフォロー、フォロワーを表示する`UsersFollows`と`UsersFollowers`を追加

### その他
前回と同様に、前のプルリクエストの変更分が含まれているようです。
マージ後に再度`push`をさせて頂きます。