### PR TITLE
ダイレクトメッセージ機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ back/storage/*
 back/.byebug_history
 back/public/uploads/post
 back/public/uploads/user
+back/public/uploads/message
 
 # Ignore master key for decrypting credentials and more.
 back/config/master.key

--- a/back/app/controllers/api/v1/user/entries_controller.rb
+++ b/back/app/controllers/api/v1/user/entries_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::User::EntriesController < Api::V1::User::Base
+
+  def check
+    user = User.find(params[:id])
+    current_user_entries = Entry.where(user_id: current_user.id)
+    user_entries = Entry.where(user_id: user.id)
+    unless user.id == current_user.id
+      current_user_entries.each do |current_user_entry|
+        user_entries.each do |user_entry|
+          if current_user_entry.room_id == user_entry.room_id
+            @isRoom = true
+            render json: {
+              entries: {
+                isRoom: true,
+                room_id: current_user_entry.room_id,
+              }
+            }
+          end
+        end
+      end
+      unless @isRoom
+        render json: {
+          entries: {
+            isRoom: false,
+          }
+        }
+      end
+    else
+      render json: {
+        entries: {
+          isRoom: false,
+        }
+      }
+    end
+  end
+
+end

--- a/back/app/controllers/api/v1/user/messages_controller.rb
+++ b/back/app/controllers/api/v1/user/messages_controller.rb
@@ -1,0 +1,46 @@
+class Api::V1::User::MessagesController < Api::V1::User::Base
+  def create
+    if Entry.where(:user_id => params[:message][:user_id], :room_id => params[:message][:room_id]).present?
+      @message = Message.create(params.require(:message).permit(:user_id, :room_id, :content, :image))
+      if @message.save
+        @room = Room.find(params[:message][:room_id])
+        messages = @room.messages.limit(15).order("created_at DESC").reverse
+        messageArray = []
+        messages.each do |message|
+          messageObj = {}
+          messageObj["id"] = message.id
+          messageObj["user_id"] = message.user_id
+          messageObj["room_id"] = message.room_id
+          messageObj["content"] = message.content
+          messageObj["image"] = message.image
+          messageObj["created_at"] = message.created_at.strftime('%Y/%m/%d')
+          user = User.find_by(id: message.user_id)
+          user_nickname = user.nickname
+          messageObj["nickname"] = user_nickname
+          user_icon = user.image
+          messageObj["icon"] = user_icon
+          messageArray.push(messageObj)
+        end
+  
+        entries = @room.entries
+        userArray = []
+        entries.each do |entry|
+          user = User.find_by(id: entry.user_id)
+          userObj = {}
+          userObj["id"] = user.id
+          userObj["nickname"] = user.nickname
+          userObj["icon"] = user.image
+          userArray.push(userObj)
+        end
+  
+        render json: {
+          room: {
+            id: @room.id,
+            messages: messageArray,
+            users: userArray
+          }
+        }
+      end
+    end
+  end
+end

--- a/back/app/controllers/api/v1/user/rooms_controller.rb
+++ b/back/app/controllers/api/v1/user/rooms_controller.rb
@@ -1,0 +1,77 @@
+class Api::V1::User::RoomsController < Api::V1::User::Base
+  def create
+    @room = Room.create
+    current_user_entry = Entry.create(:room_id => @room.id, :user_id => current_user.id)
+    users_entry = Entry.create(params.require(:room).permit(:user_id, :room_id).merge(:room_id => @room.id))
+    if @room.save
+      if current_user_entry.save
+        if users_entry.save
+          messageArray = []
+
+          entries = @room.entries
+          userArray = []
+          entries.each do |entry|
+            user = User.find_by(id: entry.user_id)
+            userObj = {}
+            userObj["id"] = user.id
+            userObj["nickname"] = user.nickname
+            userObj["icon"] = user.image
+            userArray.push(userObj)
+          end
+    
+          render json: {
+            room: {
+              id: @room.id,
+              messages: messageArray,
+              users: userArray
+            }
+          }
+        end
+      end
+    end
+  end
+
+  def show
+    @room = Room.find(params[:id])
+    if Entry.where(user_id: current_user.id, room_id: @room.id).present?
+
+      messages = @room.messages.limit(15).order("created_at DESC").reverse
+      messageArray = []
+      messages.each do |message|
+        messageObj = {}
+        messageObj["id"] = message.id
+        messageObj["user_id"] = message.user_id
+        messageObj["room_id"] = message.room_id
+        messageObj["content"] = message.content
+        messageObj["image"] = message.image
+        messageObj["created_at"] = message.created_at.strftime('%Y/%m/%d')
+        user = User.find_by(id: message.user_id)
+        user_nickname = user.nickname
+        messageObj["nickname"] = user_nickname
+        user_icon = user.image
+        messageObj["icon"] = user_icon
+        messageArray.push(messageObj)
+      end
+
+      entries = @room.entries
+      userArray = []
+      entries.each do |entry|
+        user = User.find_by(id: entry.user_id)
+        userObj = {}
+        userObj["id"] = user.id
+        userObj["nickname"] = user.nickname
+        userObj["icon"] = user.image
+        userArray.push(userObj)
+      end
+
+      render json: {
+        room: {
+          id: @room.id,
+          messages: messageArray,
+          users: userArray
+        }
+      }
+    end
+  end
+
+end

--- a/back/app/models/entry.rb
+++ b/back/app/models/entry.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: entries
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  room_id    :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_entries_on_room_id  (room_id)
+#  index_entries_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (room_id => rooms.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Entry < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+end

--- a/back/app/models/message.rb
+++ b/back/app/models/message.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: messages
+#
+#  id         :bigint           not null, primary key
+#  content    :text(65535)
+#  image      :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  room_id    :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_messages_on_room_id  (room_id)
+#  index_messages_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (room_id => rooms.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Message < ApplicationRecord
+  mount_uploader :image, ImageUploader
+  
+  belongs_to :user
+  belongs_to :room
+end

--- a/back/app/models/room.rb
+++ b/back/app/models/room.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: rooms
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Room < ApplicationRecord
+  has_many :messages, dependent: :destroy
+  has_many :entries, dependent: :destroy
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -24,6 +24,8 @@ class User < ApplicationRecord
   has_many :followings, through: :active_relationships, source: :follower
   has_many :passive_relationships, class_name: "Relationship", foreign_key: :follower_id
   has_many :followers, through: :passive_relationships, source: :following
+  has_many :messages, dependent: :destroy
+  has_many :entries, dependent: :destroy
 
   validates :name, presence: true
   validates :nickname, presence: true

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
             post :search
           end
         end
+        post 'entries/check', to: 'entries#check'
+        resources :rooms
+        resources :messages
       end
 
       namespace :admin do

--- a/back/db/migrate/20210724035414_create_rooms.rb
+++ b/back/db/migrate/20210724035414_create_rooms.rb
@@ -1,0 +1,11 @@
+class CreateRooms < ActiveRecord::Migration[6.0]
+  def up
+    create_table :rooms do |t|
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :rooms
+  end
+end

--- a/back/db/migrate/20210724035621_create_messages.rb
+++ b/back/db/migrate/20210724035621_create_messages.rb
@@ -1,0 +1,16 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def up
+    create_table :messages do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+      t.text :content
+      t.string :image
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :messages
+  end
+end

--- a/back/db/migrate/20210724036759_create_entries.rb
+++ b/back/db/migrate/20210724036759_create_entries.rb
@@ -1,0 +1,14 @@
+class CreateEntries < ActiveRecord::Migration[6.0]
+  def up
+    create_table :entries do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :entries
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_08_052448) do
+ActiveRecord::Schema.define(version: 2021_07_24_036759) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "post_id", null: false
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 2021_07_08_052448) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "entries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["room_id"], name: "index_entries_on_room_id"
+    t.index ["user_id"], name: "index_entries_on_user_id"
+  end
+
   create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -29,6 +38,17 @@ ActiveRecord::Schema.define(version: 2021_07_08_052448) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["post_id"], name: "index_favorites_on_post_id"
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.text "content"
+    t.string "image"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["room_id"], name: "index_messages_on_room_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "post_tag_relations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -57,6 +77,11 @@ ActiveRecord::Schema.define(version: 2021_07_08_052448) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "rooms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "value", null: false
     t.string "label", null: false
@@ -78,8 +103,12 @@ ActiveRecord::Schema.define(version: 2021_07_08_052448) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "entries", "rooms"
+  add_foreign_key "entries", "users"
   add_foreign_key "favorites", "posts"
   add_foreign_key "favorites", "users"
+  add_foreign_key "messages", "rooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "post_tag_relations", "posts"
   add_foreign_key "post_tag_relations", "tags"
   add_foreign_key "posts", "users"

--- a/back/db/seeds.rb
+++ b/back/db/seeds.rb
@@ -1,4 +1,4 @@
-table_names = %w(users posts comments tags post_tag_relations favorites relationships)
+table_names = %w(users posts comments tags post_tag_relations favorites relationships rooms)
 
 table_names.each do |table_name|
   path = Rails.root.join("db", "seeds", Rails.env, "#{table_name}.rb")

--- a/back/db/seeds/development/rooms.rb
+++ b/back/db/seeds/development/rooms.rb
@@ -1,0 +1,41 @@
+Room.create! 
+@room = Room.find(1)
+
+@room.entries.create! ([
+  {
+    id: 1,
+    user_id: 1,
+    room_id: 1,
+  },
+  {
+    id: 2,
+    user_id: 5,
+    room_id: 1,
+  }
+])
+@room.messages.create! ([
+  {
+    id: 1,
+    user_id: 1,
+    room_id: 1,
+    content: "こんにちはsatoです"
+  },
+  {
+    id: 2,
+    user_id: 5,
+    room_id: 1,
+    content: "初めまして鈴木です"
+  },
+  {
+    id: 3,
+    user_id: 1,
+    room_id: 1,
+    content: "これはsatoのテストメッセージです"
+  },
+  {
+    id: 4,
+    user_id: 5,
+    room_id: 1,
+    content: "鈴木のテストメッセージです"
+  },
+])

--- a/back/spec/models/entry_spec.rb
+++ b/back/spec/models/entry_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: entries
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  room_id    :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_entries_on_room_id  (room_id)
+#  index_entries_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (room_id => rooms.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Entry, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/back/spec/models/message_spec.rb
+++ b/back/spec/models/message_spec.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: messages
+#
+#  id         :bigint           not null, primary key
+#  content    :text(65535)
+#  image      :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  room_id    :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_messages_on_room_id  (room_id)
+#  index_messages_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (room_id => rooms.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/back/spec/models/room_spec.rb
+++ b/back/spec/models/room_spec.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: rooms
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe Room, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/back/spec/requests/api/v1/user/entries_spec.rb
+++ b/back/spec/requests/api/v1/user/entries_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::User::Entries", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/back/spec/requests/api/v1/user/messages_spec.rb
+++ b/back/spec/requests/api/v1/user/messages_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::User::Messages", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/back/spec/requests/api/v1/user/rooms_spec.rb
+++ b/back/spec/requests/api/v1/user/rooms_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::User::Rooms", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/front/front-app/src/assets/style/chakraStyles.js
+++ b/front/front-app/src/assets/style/chakraStyles.js
@@ -26,7 +26,13 @@ export const DefaultFlex = (props) => {
 };
 
 export const DefaultText = (props) => {
-  return <Text fontSize={{ base: "xs", md: "lg" }} {...props} />;
+  return (
+    <Text
+      fontSize={{ base: "xs", md: "lg" }}
+      wordBreak="break-word"
+      {...props}
+    />
+  );
 };
 
 export const DefaultTitleText = (props) => {

--- a/front/front-app/src/components/organisms/directMessage/DMInputForm.jsx
+++ b/front/front-app/src/components/organisms/directMessage/DMInputForm.jsx
@@ -17,7 +17,7 @@ import { updateRoom } from "../../../reducks/rooms/operations";
 
 
 export const DMInputForm = (props) => {
-  const {roomId, currentUserId, addMessageFlag, setAddMessageFlag} = props
+  const {roomId, currentUserId} = props
   const [content, setContent] =  useState('');
   const [image, setImage] =  useState();
   const loadingState = useLoadingState(false)
@@ -53,15 +53,10 @@ export const DMInputForm = (props) => {
 
   const onClickUpdateRoom = useCallback(()=> {
     dispatch(updateRoom(formData))
-    if(addMessageFlag){
-      setAddMessageFlag(false)
-    } else {
-      setAddMessageFlag(false)
-    }
     setContent('')
     setImage()
     setPreview('')
-  },[dispatch, formData, addMessageFlag, setAddMessageFlag])
+  },[dispatch, formData])
 
   return(
     <>

--- a/front/front-app/src/components/organisms/directMessage/DMInputForm.jsx
+++ b/front/front-app/src/components/organisms/directMessage/DMInputForm.jsx
@@ -1,0 +1,122 @@
+import { useCallback, useState } from "react";
+import { Box } from "@chakra-ui/layout";
+import {
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  Button,
+} from "@chakra-ui/react"
+import AddAPhotoIcon from '@material-ui/icons/AddAPhoto';
+import CancelIcon from '@material-ui/icons/Cancel';
+import { DefaultFlex, DefaultImage } from "../../../assets/style/chakraStyles";
+import PrimaryButton from "../../atoms/button/PrimaryButton";
+import useLoadingState from "../../../hooks/useLoadingState";
+import { useDispatch } from "react-redux";
+import { updateRoom } from "../../../reducks/rooms/operations";
+
+
+export const DMInputForm = (props) => {
+  const {roomId, currentUserId, addMessageFlag, setAddMessageFlag} = props
+  const [content, setContent] =  useState('');
+  const [image, setImage] =  useState();
+  const loadingState = useLoadingState(false)
+  const dispatch = useDispatch()
+  const [preview, setPreview] = useState('');
+
+  const inputContent = useCallback((event)=> {
+    setContent(event.target.value)
+  }, [setContent])
+
+  const PreviewImage = useCallback((event) => {
+    const imageFile = event.target.files[0]
+    setPreview(window.URL.createObjectURL(imageFile))
+  },[])
+
+  const inputImage = useCallback((event)=> {
+    const file = event.target.files[0]
+    setImage(file)
+    PreviewImage(event)
+  }, [setImage, PreviewImage])
+
+  const createFormData = useCallback(()=> {
+    const formData = new FormData();
+
+    formData.append('message[user_id]', currentUserId)
+    formData.append('message[room_id]', roomId)
+    formData.append('message[content]', content)
+    if (image) formData.append('message[image]', image)
+
+    return formData
+  },[currentUserId, roomId, content, image])
+  const formData = createFormData();
+
+  const onClickUpdateRoom = useCallback(()=> {
+    dispatch(updateRoom(formData))
+    if(addMessageFlag){
+      setAddMessageFlag(false)
+    } else {
+      setAddMessageFlag(false)
+    }
+    setContent('')
+    setImage()
+    setPreview('')
+  },[dispatch, formData, addMessageFlag, setAddMessageFlag])
+
+  return(
+    <>
+      <DefaultFlex flexDirection="column">
+        <FormControl as="form">
+          <Textarea 
+            placeholder="メッセージ入力..."
+            rows="2"
+            type="content"
+            name="content"
+            fontSize={{base: "sm", md: "lg"}}
+            required={true}
+            value={content}
+            onChange={inputContent}
+          />
+        </FormControl>
+        <FormControl id="image">
+        <FormLabel>
+          <AddAPhotoIcon />
+        </FormLabel>
+        <Input
+          type="file"
+          name="image"
+          accept="image/*, .jpg, .jpeg, .png"
+          multiple={true}
+          onChange={inputImage}
+          display="none"
+        />
+        </FormControl>
+        {
+          preview ?
+          <Box>
+            <Button
+              onClick={()=> setPreview('')}
+            >
+              <CancelIcon />
+            </Button>
+            <DefaultImage 
+              src={preview}
+              alt="preview img"
+            />
+          </Box> : null
+        }
+        <PrimaryButton
+          type="submit"
+          onClick={onClickUpdateRoom}
+          isLoading={loadingState}
+          disabled={content === "" && image === undefined }
+          fontSize={{base: "sm", md: "lg"}}
+        >
+          メッセージ送信
+        </PrimaryButton>
+      </DefaultFlex>
+    </>
+  )
+}
+
+export default DMInputForm;

--- a/front/front-app/src/components/organisms/directMessage/DMInputForm.jsx
+++ b/front/front-app/src/components/organisms/directMessage/DMInputForm.jsx
@@ -28,7 +28,7 @@ export const DMInputForm = (props) => {
     setContent(event.target.value)
   }, [setContent])
 
-  const PreviewImage = useCallback((event) => {
+  const previewImage = useCallback((event) => {
     const imageFile = event.target.files[0]
     setPreview(window.URL.createObjectURL(imageFile))
   },[])
@@ -36,8 +36,8 @@ export const DMInputForm = (props) => {
   const inputImage = useCallback((event)=> {
     const file = event.target.files[0]
     setImage(file)
-    PreviewImage(event)
-  }, [setImage, PreviewImage])
+    previewImage(event)
+  }, [setImage, previewImage])
 
   const createFormData = useCallback(()=> {
     const formData = new FormData();
@@ -50,6 +50,11 @@ export const DMInputForm = (props) => {
     return formData
   },[currentUserId, roomId, content, image])
   const formData = createFormData();
+
+  const onClickCancelImage = useCallback(()=> {
+    setImage(undefined)
+    setPreview('')
+  },[])
 
   const onClickUpdateRoom = useCallback(()=> {
     dispatch(updateRoom(formData))
@@ -90,7 +95,7 @@ export const DMInputForm = (props) => {
           preview ?
           <Box>
             <Button
-              onClick={()=> setPreview('')}
+              onClick={onClickCancelImage}
             >
               <CancelIcon />
             </Button>

--- a/front/front-app/src/components/organisms/directMessage/DMShowArea.jsx
+++ b/front/front-app/src/components/organisms/directMessage/DMShowArea.jsx
@@ -1,0 +1,64 @@
+import { Divider, Flex } from "@chakra-ui/react";
+import { DefaultFlex, DefaultTitleText, DefaultUserIconImage } from "../../../assets/style/chakraStyles";
+import defaultUserIcon from "../../../assets/img/defaultUserIcon.jpeg"
+import MessageCard from "./MessageCard";
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { push } from "connected-react-router";
+
+export const DMShowArea = (props) => {
+  const {room, currentUserId} = props;
+  const dispatch = useDispatch()
+  const messages = room.messages
+  const users = room.users
+
+  const toUserInfoPage = useCallback((user)=> {
+    dispatch(push(`/users/${user.id}`))
+  },[dispatch])
+
+  return(
+    <DefaultFlex mb="4" flexDirection='column'>
+      {
+        users.length > 0 ? (
+          users.map(user => (
+            <Flex key={user.id} mr="auto" ml="auto">
+              {
+                (currentUserId !== user.id) ? (
+                  <>
+                    <DefaultUserIconImage
+                      src={user.icon.url? user.icon.url : defaultUserIcon}
+                      mr="4"
+                      onClick={() => toUserInfoPage(user)}
+                      cursor="pointer"
+                    />
+                    <DefaultTitleText
+                      onClick={() => toUserInfoPage(user)}
+                      cursor="pointer"
+                    >
+                      {user.nickname}
+                    </DefaultTitleText>
+                  </>
+                ) : null
+              }
+            </Flex>
+          ))
+        ) : null
+      }
+      <Divider mt="4" mb="4"/>
+      <DefaultFlex
+        bg="gray.100"
+        flexDirection='column'
+      >
+        {
+          messages.length > 0 ? (
+            messages.map(message => (
+              <MessageCard key={message.id} message={message}/>
+            ))
+          ) : null
+        }
+      </DefaultFlex>
+    </DefaultFlex>
+  )
+}
+
+export default DMShowArea;

--- a/front/front-app/src/components/organisms/directMessage/MessageCard.jsx
+++ b/front/front-app/src/components/organisms/directMessage/MessageCard.jsx
@@ -1,0 +1,53 @@
+import { Box, Divider, Flex } from "@chakra-ui/react"
+import { DefaultImage, DefaultText, DefaultUserIconImage } from "../../../assets/style/chakraStyles"
+import defaultUserIcon from "../../../assets/img/defaultUserIcon.jpeg"
+import useGetCurrentUserId from "../../../hooks/useGetCurrentUserId"
+
+export const MessageCard = (props) => {
+  const {message} = props
+  const currentUserId = useGetCurrentUserId()
+  const { user_id, icon, content, image, created_at} = message
+  return(
+    <Flex
+      bg="blue.200"
+      m="2"
+      p="2"
+      { ...currentUserId === user_id ? {ml: "40%"} : null}
+      borderRadius="3xl"
+      w="60%"
+      shadow="lg"
+    >
+      {
+        currentUserId !== user_id ? (
+          <DefaultUserIconImage 
+            src={icon.url? icon.url : defaultUserIcon}
+            boxSize={{ base: "20px", md: "30px" }}
+            // onClick={toUserinfoPage}
+            cursor="pointer"
+          />
+        ) : null
+      }
+      <Box w="100%" pl={{base: "2", md: "4"}} >
+        <DefaultText >{content}</DefaultText>
+        {
+          image.url ? (
+            <DefaultImage 
+              src={image.url}
+              boxSize={{ base: "16", md: "40" }}
+              minH="none"
+              minw="none"
+            />
+          ) : null
+        }
+        <Divider mt="2" mb="2" w="100%"/>
+        <DefaultText
+          fontSize={{base: "x-small", md: "sm"}}
+        >
+          {created_at}
+        </DefaultText>
+      </Box>
+    </Flex>
+  )
+}
+
+export default MessageCard;

--- a/front/front-app/src/components/organisms/entry/EntryButton.jsx
+++ b/front/front-app/src/components/organisms/entry/EntryButton.jsx
@@ -62,7 +62,7 @@ export const EntryButton = () => {
               {
                 isRoom ? (
                   <>
-                    チェットを再開
+                    チャットを再開
                   </>
                 ) : (
                   <>

--- a/front/front-app/src/components/organisms/entry/EntryButton.jsx
+++ b/front/front-app/src/components/organisms/entry/EntryButton.jsx
@@ -1,0 +1,81 @@
+import axios from "axios";
+import { push } from "connected-react-router";
+import { useCallback, useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useParams } from "react-router";
+import useGetCurrentUserId from "../../../hooks/useGetCurrentUserId";
+import { createRoom } from "../../../reducks/rooms/operations";
+import BooleanButton from "../../atoms/button/BooleanButton";
+
+export const EntryButton = () => {
+  const userId = useParams();
+  const currentUserId = useGetCurrentUserId()
+  const [isRoom, setIsRoom] = useState(false)
+  const [roomId, setRoomId] = useState('')
+  const dispatch = useDispatch()
+  
+  // 既存のルームがあるか確認
+  const checkIsRoom = useCallback(()=> {
+    axios
+      .post(
+        "http://localhost:3001/api/v1/user/entries/check",
+        userId,
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        const res = response.data.entries.isRoom
+        if (res) {
+          setIsRoom(res)
+          setRoomId(response.data.entries.room_id)
+        } else {
+          setIsRoom(res)
+        }
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+  },[userId])
+  
+  useEffect(()=> {
+    checkIsRoom()
+  },[checkIsRoom])
+
+  const toRoom = useCallback(()=> {
+    if(isRoom) {
+      dispatch(push(`/room/${roomId}`))
+    } else {
+      dispatch(createRoom(userId))
+    }
+  },[isRoom, roomId, userId, dispatch])
+
+  return(
+    <>
+      {
+        Number(userId.id) !== currentUserId
+          ? (
+            <BooleanButton
+              colorBoolean={isRoom}
+              onClick={toRoom}
+            >
+              {
+                isRoom ? (
+                  <>
+                    チェットを再開
+                  </>
+                ) : (
+                  <>
+                    チャットを開始
+                  </>
+                )
+              }
+            </BooleanButton>
+          )
+          : null
+      }
+    </>
+  )
+}
+
+export default EntryButton;

--- a/front/front-app/src/components/organisms/users/UsersShowCard.jsx
+++ b/front/front-app/src/components/organisms/users/UsersShowCard.jsx
@@ -13,6 +13,7 @@ import { DefaultFlex, DefaultText, DefaultTitleText, DefaultUserIconImage } from
 import defaultUserIcon from '../../../assets/img/defaultUserIcon.jpeg'
 import useLoadingState from '../../../hooks/useLoadingState'
 import useGetCurrentUserId from '../../../hooks/useGetCurrentUserId'
+import EntryButton from '../entry/EntryButton'
 
 export const UsersShowCard = () => {
 
@@ -92,6 +93,7 @@ export const UsersShowCard = () => {
               </BooleanButton>
               ) : null
             }
+            <EntryButton />
           </Flex>
           <Divider 
             mb="2"

--- a/front/front-app/src/components/pages/Room.jsx
+++ b/front/front-app/src/components/pages/Room.jsx
@@ -1,0 +1,43 @@
+import { Center, Spinner } from "@chakra-ui/react"
+import { useEffect, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { useParams } from "react-router"
+import useGetCurrentUserId from "../../hooks/useGetCurrentUserId"
+import useLoadingState from "../../hooks/useLoadingState"
+import { getRoom } from "../../reducks/rooms/operations"
+import DMInputForm from "../organisms/directMessage/DMInputForm"
+import { DMShowArea } from "../organisms/directMessage/DMShowArea"
+
+
+
+export const Room = () => {
+  const roomId = useParams()
+  const dispatch = useDispatch()
+  const loadingState = useLoadingState()
+  const currentUserId = useGetCurrentUserId()
+  const [addMessageFlag, setAddMessageFlag] = useState(false)
+
+  useEffect(()=> {
+    dispatch(getRoom(roomId))
+  },[dispatch, roomId])
+
+  const room = useSelector((state)=> state.room)
+
+  return(
+    <>
+      { loadingState? (
+        <Center  h="100vh" w={{base: "50vh", md: "100vh"}}>
+          <Spinner/>
+        </Center>
+        ): (
+          <>
+            <DMShowArea room={room} currentUserId={currentUserId}/>
+          </>
+        )
+      }
+      <DMInputForm roomId={room.id} currentUserId={currentUserId} addMessageFlag={addMessageFlag} setAddMessageFlag={setAddMessageFlag}/>
+    </>
+  )
+}
+
+export default Room;

--- a/front/front-app/src/components/pages/Room.jsx
+++ b/front/front-app/src/components/pages/Room.jsx
@@ -1,5 +1,5 @@
 import { Center, Spinner } from "@chakra-ui/react"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { useParams } from "react-router"
 import useGetCurrentUserId from "../../hooks/useGetCurrentUserId"
@@ -15,7 +15,6 @@ export const Room = () => {
   const dispatch = useDispatch()
   const loadingState = useLoadingState()
   const currentUserId = useGetCurrentUserId()
-  const [addMessageFlag, setAddMessageFlag] = useState(false)
 
   useEffect(()=> {
     dispatch(getRoom(roomId))
@@ -35,7 +34,7 @@ export const Room = () => {
           </>
         )
       }
-      <DMInputForm roomId={room.id} currentUserId={currentUserId} addMessageFlag={addMessageFlag} setAddMessageFlag={setAddMessageFlag}/>
+      <DMInputForm roomId={room.id} currentUserId={currentUserId}/>
     </>
   )
 }

--- a/front/front-app/src/components/pages/posts/PostEdit.jsx
+++ b/front/front-app/src/components/pages/posts/PostEdit.jsx
@@ -51,7 +51,7 @@ export const PostEdit = ()=> {
     setContent(event.target.value)
   }, [setContent])
 
-  const PreviewImage = useCallback((e) => {
+  const previewImage = useCallback((e) => {
     const imageFile = e.target.files[0]
     setPreview(window.URL.createObjectURL(imageFile))
   },[setPreview])
@@ -59,8 +59,8 @@ export const PostEdit = ()=> {
   const inputImage = useCallback((event)=> {
     const file = event.target.files[0]
     setImage(file)
-    PreviewImage(event)
-  }, [setImage, PreviewImage])
+    previewImage(event)
+  }, [setImage, previewImage])
 
 
   // 編集権限者か確認、権限者でない場合はTOPページへリダレクト
@@ -119,6 +119,11 @@ export const PostEdit = ()=> {
   },[currentUserId, title, tags, content, image])
   const formData = createFormData();
   const showMessage = useMessage()
+
+  const onClickCancelImage = useCallback(()=> {
+    setImage(undefined)
+    setPreview('')
+  },[])
 
   return(
     <>
@@ -180,7 +185,7 @@ export const PostEdit = ()=> {
                 preview ?
                 <Box>
                   <Button
-                    onClick={()=> setPreview('')}
+                    onClick={onClickCancelImage}
                   >
                     <CancelIcon />
                   </Button>

--- a/front/front-app/src/components/pages/posts/PostNew.jsx
+++ b/front/front-app/src/components/pages/posts/PostNew.jsx
@@ -48,7 +48,7 @@ export const PostNew = ()=> {
     setContent(event.target.value)
   }, [setContent])
 
-  const PreviewImage = useCallback((event) => {
+  const previewImage = useCallback((event) => {
     const imageFile = event.target.files[0]
     setPreview(window.URL.createObjectURL(imageFile))
   },[])
@@ -56,8 +56,8 @@ export const PostNew = ()=> {
   const inputImage = useCallback((event)=> {
     const file = event.target.files[0]
     setImage(file)
-    PreviewImage(event)
-  }, [setImage, PreviewImage])
+    previewImage(event)
+  }, [setImage, previewImage])
   
   const createFormData = useCallback(()=> {
     const formData = new FormData();
@@ -74,6 +74,11 @@ export const PostNew = ()=> {
     return formData
   },[currentUserId, title, tags, content, image])
   const formData = createFormData();
+
+  const onClickCancelImage = useCallback(()=> {
+    setImage(undefined)
+    setPreview('')
+  },[])
 
 
   return(
@@ -128,7 +133,7 @@ export const PostNew = ()=> {
           preview ?
           <Box>
             <Button
-              onClick={()=> setPreview('')}
+              onClick={onClickCancelImage}
             >
               <CancelIcon />
             </Button>

--- a/front/front-app/src/reducks/rooms/actions.js
+++ b/front/front-app/src/reducks/rooms/actions.js
@@ -1,0 +1,29 @@
+export const CREATE_ROOM = "CREATE_ROOM";
+export const createRoomAction = (roomStatus) => {
+  return {
+    type: CREATE_ROOM,
+    payload: {
+      ...roomStatus,
+    },
+  };
+};
+
+export const GET_ROOM = "GET_ROOM";
+export const getRoomAction = (roomStatus) => {
+  return {
+    type: GET_ROOM,
+    payload: {
+      ...roomStatus,
+    },
+  };
+};
+
+export const UPDATE_ROOM = "UPDATE_ROOM";
+export const updateRoomAction = (roomStatus) => {
+  return {
+    type: UPDATE_ROOM,
+    payload: {
+      ...roomStatus,
+    },
+  };
+};

--- a/front/front-app/src/reducks/rooms/operations.js
+++ b/front/front-app/src/reducks/rooms/operations.js
@@ -1,0 +1,84 @@
+import axios from "axios";
+import { push } from "connected-react-router";
+import { nowLoadingAction } from "../loading/actions";
+import { createRoomAction, getRoomAction, updateRoomAction } from "./actions";
+
+export const createRoom = (userId) => {
+  return async (dispatch) => {
+    axios
+      .post(
+        "http://localhost:3001/api/v1/user/rooms",
+        {
+          room: {
+            user_id: userId.id,
+          },
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        dispatch(createRoomAction(response.data.room));
+        const roomId = response.data.room.id;
+        dispatch(push(`/room/${roomId}`));
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      });
+  };
+};
+
+export const getRoom = (roomId) => {
+  return async (dispatch) => {
+    dispatch(nowLoadingAction(true));
+    axios
+      .get(`http://localhost:3001/api/v1/user/rooms/${roomId.id}`, {
+        withCredentials: true,
+      })
+      .then((response) => {
+        if (response.data) {
+          dispatch(getRoomAction(response.data.room));
+        } else {
+          dispatch(push("/posts"));
+        }
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+      .finally(() => {
+        setTimeout(() => {
+          dispatch(nowLoadingAction(false));
+        }, 800);
+      });
+  };
+};
+
+export const updateRoom = (formData) => {
+  return async (dispatch) => {
+    dispatch(nowLoadingAction(true));
+    axios
+      .post(
+        "http://localhost:3001/api/v1/user/messages",
+        formData,
+        {
+          headers: {
+            "content-type": "multipart/form-data",
+          },
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        dispatch(updateRoomAction(response.data.room));
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+      .finally(() => {
+        setTimeout(() => {
+          dispatch(nowLoadingAction(false));
+        }, 800);
+      });
+  };
+};

--- a/front/front-app/src/reducks/rooms/reducers.js
+++ b/front/front-app/src/reducks/rooms/reducers.js
@@ -1,0 +1,24 @@
+import * as Actions from "./actions";
+import initialState from "../store/initialState";
+
+export const RoomReducer = (state = initialState.room, action) => {
+  switch (action.type) {
+    case Actions.CREATE_ROOM:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.GET_ROOM:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.UPDATE_ROOM:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    default:
+      return state;
+  }
+};

--- a/front/front-app/src/reducks/store/initialState.js
+++ b/front/front-app/src/reducks/store/initialState.js
@@ -36,6 +36,16 @@ const initialState = {
   follow: {
     status: false,
   },
+
+  room: {
+    id: "",
+    users: {
+      list: [],
+    },
+    messages: {
+      list: [],
+    },
+  },
 };
 
 export default initialState;

--- a/front/front-app/src/reducks/store/store.js
+++ b/front/front-app/src/reducks/store/store.js
@@ -14,6 +14,7 @@ import { CommentsReducer } from "../comments/reducers";
 import { TagsReducer } from "../tags/reducers";
 import { FavoriteReducer } from "../favorite/reducers";
 import { FollowReducer } from "../follow/reducers";
+import { RoomReducer } from "../rooms/reducers";
 
 export default function createState(history) {
   return reduxCreateStore(
@@ -27,6 +28,7 @@ export default function createState(history) {
       tags: TagsReducer,
       favorite: FavoriteReducer,
       follow: FollowReducer,
+      room: RoomReducer,
     }),
     applyMiddleware(routerMiddleware(history), thunk)
   );

--- a/front/front-app/src/router/Router.jsx
+++ b/front/front-app/src/router/Router.jsx
@@ -16,6 +16,7 @@ import FavoritePosts from '../components/pages/mypage/FavoritePosts'
 import Follows from '../components/pages/mypage/Follows'
 import Followers from '../components/pages/mypage/Followers'
 import SearchResult from '../components/pages/SearchResult'
+import Room from '../components/pages/Room'
 
 export const Router = () => {
   return(
@@ -33,8 +34,9 @@ export const Router = () => {
           <Route path={"/mypage/:id/posts"} component={MyPosts} />
           <Route path={"/mypage/:id/follows"} component={Follows} />
           <Route path={"/mypage/:id/followers"} component={Followers} />
-          <Route path={"/searchResult"} component={SearchResult} />
           <Route path={"/mypage/:id/favoritePosts"} component={FavoritePosts} />
+          <Route path={"/searchResult"} component={SearchResult} />
+          <Route path={"/room/:id"} component={Room} />
           <Route path={"/users/:id"} component={UsersInfo} />
         </DefaultLayout>
       </Auth>


### PR DESCRIPTION
## ダイレクトメッセージ機能追加

### 変更詳細
- ユーザー詳細画面(/users/:id)に新たにチャットルームへ遷移するボタンを設置
- クリックすると自動で自分のIDと相手側のIDを保持したルームが作成され一対一のメッセージの
やり取りが可能
- ルームで保持しているユーザー以外がアクセスしようとするとトップページへリダイレクト
- メッセージとしてテキストと画像を投稿可能(作成のみ、編集、削除は無し)
- 表示は下部が一番最新になり、最新15件を表示

### 動作環境

確認される不具合はございません。

※今回のプルリクエスト以前に、こちら側でリクエストを出さずにマージした変更内容が
ございます(主な変更内容がバックエンドのため)。
一旦、現在の`GitHub`のマスターブランチを取り込んで頂いてから今回の変更分を
ご確認頂ければと存じます。

ダイレクトメッセージに掛かる初期データを作成しているので以下のコマンドの実行を
宜しくお願い致します。

```
docker-compose run back db:reset
```
以下のユーザー間でダイレクトメッセージのテストデータを投入しております。
```
ユーザー1
ユーザー名:  佐藤二郎
ニックネーム: sato
メールアドレス: sample@example.com
パスワード: password

ユーザー2
ユーザー名:  鈴木愛
ニックネーム: 鈴木
メールアドレス: sample4@example.com
パスワード: password

```

### 主な変更箇所
- `reducks/rooms/operations`にルーム作成とメッセージ投稿によるルーム更新をするための関数を追加
- `conponents/organisms/entry`にユーザー詳細ページに設置しているチャットルームへ遷移するボタンを追加
(ルームが既にあるユーザーとまだルームが作成されていないユーザーとで表示、処理を区分している)
- `components/organisms/directMessage`に主なviewに関わるコンポーネントを作成

### 保留していること
メッセージの編集、削除の実装するか否かは検討中
メッセージは最新15件のみ取得してそれより前は非表示になるが、ページネーションの
導入は検討中
作成されているチャットルーム一覧を表示させるページは次回以降で作成

### その他
今回新規に追加したファイルは34ですが、React側の新規追加は10ファイル前後になります。
急ぎではございませんのでお時間がある際にご確認を宜しくお願い致します。