### PR TITLE
メッセージがない場合のメッセージエリアの非表示

### DIFF
--- a/front/front-app/src/components/organisms/directMessage/DMShowArea.jsx
+++ b/front/front-app/src/components/organisms/directMessage/DMShowArea.jsx
@@ -45,18 +45,20 @@ export const DMShowArea = (props) => {
         ) : null
       }
       <Divider mt="4" mb="4"/>
-      <DefaultFlex
-        bg="gray.100"
-        flexDirection='column'
-      >
-        {
-          messages.length > 0 ? (
-            messages.map(message => (
-              <MessageCard key={message.id} message={message}/>
-            ))
-          ) : null
-        }
-      </DefaultFlex>
+      {
+        messages.length > 0 ? (
+          <DefaultFlex
+            bg="gray.100"
+            flexDirection='column'
+          >
+            {
+              messages.map(message => (
+                <MessageCard key={message.id} message={message}/>
+              ))
+            }
+          </DefaultFlex>
+        ) : null
+      }
     </DefaultFlex>
   )
 }


### PR DESCRIPTION
## メッセージがない場合のメッセージエリアの非表示

> メッセージが１つもない時、メッセージエリアがなんなのかわかりづらく感じました。メッセージがない場合はエリア自体表示しなくても良いかもしれません。

コードに関しては以下のように修正致しました。

```
  {
        messages.length > 0 ? (
          <DefaultFlex
            bg="gray.100"
            flexDirection='column'
          >
            {
              messages.map(message => (
                <MessageCard key={message.id} message={message}/>
              ))
            }
          </DefaultFlex>
        ) : null
      }
 
 ```

メッセージエリアをすべて`messages.length > 0 ? `の条件式の中に含めるように変更しました。
現在はメッセージがない場合は以下のように表示されております。


<img width="701" alt="FA069723-1C0C-431B-8626-44D4D7014F5F" src="https://user-images.githubusercontent.com/66899822/127417065-5569978d-184e-40b9-8b3c-242a1cf866ef.png">
