### PR TITLE
メッセージ投稿時のローディング

### DIFF
--- a/front/front-app/src/components/organisms/directMessage/DMShowArea.jsx
+++ b/front/front-app/src/components/organisms/directMessage/DMShowArea.jsx
@@ -45,18 +45,20 @@ export const DMShowArea = (props) => {
         ) : null
       }
       <Divider mt="4" mb="4"/>
-      <DefaultFlex
-        bg="gray.100"
-        flexDirection='column'
-      >
-        {
-          messages.length > 0 ? (
-            messages.map(message => (
-              <MessageCard key={message.id} message={message}/>
-            ))
-          ) : null
-        }
-      </DefaultFlex>
+      {
+        messages.length > 0 ? (
+          <DefaultFlex
+            bg="gray.100"
+            flexDirection='column'
+          >
+            {
+              messages.map(message => (
+                <MessageCard key={message.id} message={message}/>
+              ))
+            }
+          </DefaultFlex>
+        ) : null
+      }
     </DefaultFlex>
   )
 }

--- a/front/front-app/src/reducks/rooms/operations.js
+++ b/front/front-app/src/reducks/rooms/operations.js
@@ -55,7 +55,6 @@ export const getRoom = (roomId) => {
 
 export const updateRoom = (formData) => {
   return async (dispatch) => {
-    dispatch(nowLoadingAction(true));
     axios
       .post(
         "http://localhost:3001/api/v1/user/messages",
@@ -74,11 +73,6 @@ export const updateRoom = (formData) => {
       })
       .catch((error) => {
         console.log("error:", error);
-      })
-      .finally(() => {
-        setTimeout(() => {
-          dispatch(nowLoadingAction(false));
-        }, 800);
       });
   };
 };


### PR DESCRIPTION
## プログレス表示

> メッセージ送信中に、相手のアイコンや既存のメッセージなどが消えて、プログレス表示になりますが、それらは残した上でプログレス表示を行った方が良いと思います。

`operations`ファイルのメッセージ投稿時の関数`updateRoom`の中に記載されていた
`loading`の状態に関する記載を削除することで`(dispatch(nowLoadingAction(true));)`、
ページ遷移に一度だけローディング表示をさせて以降のメッセージ投稿際には
余計な`loading`が走らずに差分だけが画面に表示されるように修正致しました。