### PR TITLE
ページネーション修正

### DIFF
--- a/back/app/controllers/api/v1/user/messages_controller.rb
+++ b/back/app/controllers/api/v1/user/messages_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::User::MessagesController < Api::V1::User::Base
           messageObj["room_id"] = message.room_id
           messageObj["content"] = message.content
           messageObj["image"] = message.image
-          messageObj["created_at"] = message.created_at.strftime('%Y/%m/%d')
+          messageObj["created_at"] = message.created_at.strftime('%Y/%m/%d %H:%M')
           user = User.find_by(id: message.user_id)
           user_nickname = user.nickname
           messageObj["nickname"] = user_nickname

--- a/back/app/controllers/api/v1/user/rooms_controller.rb
+++ b/back/app/controllers/api/v1/user/rooms_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::User::RoomsController < Api::V1::User::Base
         messageObj["room_id"] = message.room_id
         messageObj["content"] = message.content
         messageObj["image"] = message.image
-        messageObj["created_at"] = message.created_at.strftime('%Y/%m/%d')
+        messageObj["created_at"] = message.created_at.strftime('%Y/%m/%d %H:%M')
         user = User.find_by(id: message.user_id)
         user_nickname = user.nickname
         messageObj["nickname"] = user_nickname

--- a/front/front-app/src/hooks/usePagination.jsx
+++ b/front/front-app/src/hooks/usePagination.jsx
@@ -6,7 +6,7 @@ export const usePagination = () => {
 
   const {search} = useLocation()
   const query = new URLSearchParams(search);
-  const queryPageStr = query.get("page")
+  const queryPageStr = query.get("page") ? query.get("page") : "1"
   const queryPage = Number(queryPageStr)
   return { sumPage, setSumPage ,queryPage}
 }


### PR DESCRIPTION
## ページネーション修正

> 初期状態で、１ページしかないのに右矢印が有効になっている。
初期状態で、現在のページがハイライトされていない。
号が大きいほど過去の書き込みなのか、最新の書き込みなのか分かりにくい。

以下の修正で、ページ数1の際の矢印の無効化、ハイライト化
メッセージ投稿時間を付与して最新のメッセージの区別化を図ってみました。