### PR TITLE
通知機能追加

### DIFF
--- a/back/app/controllers/api/v1/user/comments_controller.rb
+++ b/back/app/controllers/api/v1/user/comments_controller.rb
@@ -28,6 +28,8 @@ class Api::V1::User::CommentsController < Api::V1::User::Base
     comment = Comment.new(comment_params)
     if comment.save
       render json: comment
+      post = comment.post
+      post.create_notification_comment!(current_user, comment.id)
     end
   end
 

--- a/back/app/controllers/api/v1/user/favorites_controller.rb
+++ b/back/app/controllers/api/v1/user/favorites_controller.rb
@@ -22,6 +22,8 @@ class Api::V1::User::FavoritesController < Api::V1::User::Base
     favorite = user.favorites.build(post_id: params[:post_id])
     if favorite.save
       render json: true
+      post = Post.find(params[:post_id])
+      post.create_notification_favorite!(current_user)
     end
   end
 

--- a/back/app/controllers/api/v1/user/messages_controller.rb
+++ b/back/app/controllers/api/v1/user/messages_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::User::MessagesController < Api::V1::User::Base
             messageObj["icon"] = user_icon
             messageArray.push(messageObj)
           end
-    
+          
           entries = @room.entries
           userArray = []
           entries.each do |entry|
@@ -44,6 +44,11 @@ class Api::V1::User::MessagesController < Api::V1::User::Base
             },
             page_length: page_length
           }
+
+          current_user = User.find(params[:message][:user_id])
+          entry = Entry.where(room_id: @room.id).where.not(user_id: current_user.id)
+          user = User.find(*entry.pluck(:user_id))
+          @message.create_notification_message!(current_user, user)
         end
       end
     end

--- a/back/app/controllers/api/v1/user/notifications_controller.rb
+++ b/back/app/controllers/api/v1/user/notifications_controller.rb
@@ -1,0 +1,76 @@
+class Api::V1::User::NotificationsController < Api::V1::User::Base
+
+  def unchecked_notifications
+    notifications = current_user.passive_notifications.where(checked: false)
+    if notifications.any?
+      render json: true
+    else
+      render json: false
+    end
+  end
+
+  def index
+    notifications = current_user.passive_notifications.page(params[:page] ||=1).per(10)
+    page_length = notifications.page(1).per(10).total_pages
+    notifications.where(checked: false).each do |notification|
+      notification.update_attributes(checked: true)
+    end
+    notificationsArray = []
+    notifications.each do |notification|
+      notificationObj = {}
+      notificationObj["id"] = notification.id
+      notificationObj["post_id"] = notification.post_id
+      notificationObj["visited_id"] = notification.visited_id
+      notificationObj["visitor_id"] = notification.visitor_id
+      notificationObj["room_id"] = notification.room_id
+      notificationObj["message_id"] = notification.message_id
+      user = User.find_by(id: notification.visitor_id)
+      notificationObj["nickname"] = user.nickname
+      notificationObj["icon"] = user.image
+      notificationObj["created_at"] = notification.created_at.strftime('%Y/%m/%d %H:%M')
+      notificationObj["checked"] = notification.checked      
+      notificationObj["action"] = notification.action   
+      notificationsArray.push(notificationObj)
+    end
+    data = {
+      notifications: notificationsArray,
+      page_length: page_length,
+    }
+    render json: data
+  end
+
+  def destroy
+    notification = Notification.find(params[:id])
+    notification.destroy
+
+    notifications = current_user.passive_notifications.page(params[:page] ||=1).per(10)
+    page_length = notifications.page(1).per(10).total_pages
+    notificationsArray = []
+    notifications.each do |notification|
+      notificationObj = {}
+      notificationObj["id"] = notification.id
+      notificationObj["post_id"] = notification.post_id
+      notificationObj["visited_id"] = notification.visited_id
+      notificationObj["visitor_id"] = notification.visitor_id
+      notificationObj["room_id"] = notification.room_id
+      notificationObj["message_id"] = notification.message_id
+      user = User.find_by(id: notification.visitor_id)
+      notificationObj["nickname"] = user.nickname
+      notificationObj["icon"] = user.image
+      notificationObj["created_at"] = notification.created_at.strftime('%Y/%m/%d %H:%M')
+      notificationObj["checked"] = notification.checked      
+      notificationObj["action"] = notification.action   
+      notificationsArray.push(notificationObj)
+    end
+    data = {
+      notifications: notificationsArray,
+      page_length: page_length,
+    }
+    render json: data
+  end
+
+  def destroy_all
+    notifications = Notification.where(visited_id: current_user.id)
+    notifications.destroy_all
+  end
+end

--- a/back/app/controllers/api/v1/user/relationships_controller.rb
+++ b/back/app/controllers/api/v1/user/relationships_controller.rb
@@ -15,6 +15,8 @@ class Api::V1::User::RelationshipsController < Api::V1::User::Base
       follow = current_user.active_relationships.build(follower_id: params[:user_id])
       if follow.save
         render json: true
+        user = User.find(params[:user_id])
+        user.create_notification_follow!(current_user)
       end
     end
   end

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -20,6 +20,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Comment < ApplicationRecord
+  has_many :notifications, dependent: :destroy
   belongs_to :post
 
   validates :comment, presence: true

--- a/back/app/models/message.rb
+++ b/back/app/models/message.rb
@@ -23,6 +23,21 @@
 class Message < ApplicationRecord
   mount_uploader :image, ImageUploader
   
+  has_many :notifications, dependent: :destroy
   belongs_to :user
   belongs_to :room
+
+  def create_notification_message!(current_user, user)
+    notification = current_user.active_notifications.new(
+      room_id: room_id,
+      visitor_id: current_user.id,
+      visited_id: user.id,
+      message_id: id,
+      action: 'message',
+    )
+    if notification.visitor_id == notification.visited_id
+      notification.checked = true
+    end
+    notification.save if notification.valid?
+  end
 end

--- a/back/app/models/notification.rb
+++ b/back/app/models/notification.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id         :bigint           not null, primary key
+#  action     :string(255)      default(""), not null
+#  checked    :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  comment_id :integer
+#  message_id :integer
+#  post_id    :integer
+#  room_id    :integer
+#  visited_id :integer          not null
+#  visitor_id :integer          not null
+#
+# Indexes
+#
+#  index_notifications_on_comment_id  (comment_id)
+#  index_notifications_on_post_id     (post_id)
+#  index_notifications_on_visited_id  (visited_id)
+#  index_notifications_on_visitor_id  (visitor_id)
+#
+class Notification < ApplicationRecord
+  default_scope -> { order(created_at: :desc) }
+  belongs_to :post, optional: true
+  belongs_to :comment, optional: true
+  belongs_to :message, optional: true
+
+  belongs_to :visitor, class_name: 'User', foreign_key: 'visitor_id', optional: true
+  belongs_to :visited, class_name: 'User', foreign_key: 'visited_id', optional: true
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -26,10 +26,51 @@ class Post < ApplicationRecord
   has_many :post_tag_relations, foreign_key: :post_id, dependent: :destroy
   has_many :tags, through: :post_tag_relations, foreign_key: :post_id, dependent: :destroy
   has_many :favorites, dependent: :delete_all
+  has_many :notifications, dependent: :destroy
   
   belongs_to :user
 
 
   validates :title, presence: true
   validates :content, presence: true
+
+  def create_notification_favorite!(current_user)
+    temp = Notification.where(["visitor_id = ? and visited_id = ? and post_id = ? and action = ?", current_user.id, user_id, id, 'favorite'])
+    if temp.blank?
+      if current_user.id != user_id
+        notification = current_user.active_notifications.new(
+          post_id: id,
+          visited_id: user_id,
+          action: 'favorite'
+        )
+        if notification.visitor_id == notification.visited_id
+          notification.checked = true
+        end
+        notification.save if notification.valid?
+      end
+    end
+  end
+
+  def create_notification_comment!(current_user, comment_id)
+    temp_ids = Comment.select(:user_id).where(post_id: id).where.not(user_id: current_user.id).distinct
+    temp_ids.each do |temp_id|
+      save_notification_comment!(current_user, comment_id, temp_id['user_id'])
+    end
+    save_notification_comment!(current_user, comment_id, user_id) if temp_ids.blank?
+  end
+
+  def save_notification_comment!(current_user, comment_id, visited_id)
+    if current_user.id != visited_id
+      notification = current_user.active_notifications.new(
+        post_id: id,
+        comment_id: comment_id,
+        visited_id: visited_id,
+        action: 'comment'
+      )
+      if notification.visitor_id == notification.visited_id
+        notification.checked = true
+      end
+      notification.save if notification.valid?
+    end
+  end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -26,10 +26,23 @@ class User < ApplicationRecord
   has_many :followers, through: :passive_relationships, source: :following
   has_many :messages, dependent: :destroy
   has_many :entries, dependent: :destroy
+  has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
+  has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
 
   validates :name, presence: true
   validates :nickname, presence: true
   validates :email, presence: true
   validates :email, presence: true, uniqueness: { case_sensitive: false }
   validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+
+  def create_notification_follow!(current_user)
+    temp = Notification.where(["visitor_id = ? and visited_id = ? and action = ? ",current_user.id, id, 'follow'])
+    if temp.blank?
+      notification = current_user.active_notifications.new(
+        visited_id: id,
+        action: 'follow'
+      )
+      notification.save if notification.valid?
+    end
+  end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -54,6 +54,12 @@ Rails.application.routes.draw do
         resources :rooms, only: [:index, :create, :show] do
         end
         resources :messages
+        resources :notifications, only: [:index, :destroy] do
+          collection do
+            get :unchecked_notifications
+            delete :destroy_all
+          end
+        end
       end
 
       namespace :admin do

--- a/back/db/migrate/20210801070501_create_notifications.rb
+++ b/back/db/migrate/20210801070501_create_notifications.rb
@@ -1,0 +1,25 @@
+class CreateNotifications < ActiveRecord::Migration[6.0]
+  def up 
+    create_table :notifications do |t|
+      t.integer :visitor_id, null: false
+      t.integer :visited_id, null: false
+      t.integer :post_id
+      t.integer :comment_id
+      t.integer :room_id
+      t.integer :message_id
+      t.string :action, default: '', null: false
+      t.boolean :checked, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :notifications, :visitor_id
+    add_index :notifications, :visited_id
+    add_index :notifications, :post_id
+    add_index :notifications, :comment_id
+  end
+
+  def down
+    drop_table :notifications
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_24_036759) do
+ActiveRecord::Schema.define(version: 2021_08_01_070501) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "post_id", null: false
@@ -49,6 +49,23 @@ ActiveRecord::Schema.define(version: 2021_07_24_036759) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["room_id"], name: "index_messages_on_room_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "visitor_id", null: false
+    t.integer "visited_id", null: false
+    t.integer "post_id"
+    t.integer "comment_id"
+    t.integer "room_id"
+    t.integer "message_id"
+    t.string "action", default: "", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["comment_id"], name: "index_notifications_on_comment_id"
+    t.index ["post_id"], name: "index_notifications_on_post_id"
+    t.index ["visited_id"], name: "index_notifications_on_visited_id"
+    t.index ["visitor_id"], name: "index_notifications_on_visitor_id"
   end
 
   create_table "post_tag_relations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/back/db/seeds.rb
+++ b/back/db/seeds.rb
@@ -1,4 +1,4 @@
-table_names = %w(users posts comments tags post_tag_relations favorites relationships rooms)
+table_names = %w(users posts comments tags post_tag_relations favorites relationships rooms notifications)
 
 table_names.each do |table_name|
   path = Rails.root.join("db", "seeds", Rails.env, "#{table_name}.rb")

--- a/back/db/seeds/development/notifications.rb
+++ b/back/db/seeds/development/notifications.rb
@@ -1,0 +1,41 @@
+5.times do |n|
+  current_user = User.find(n + 1)
+  other_user = User.find(n + 2 > 5 ? 1 : n + 2)
+  post = other_user.posts[0]
+  comments = post.comments.where(user_id: current_user.id)
+  room = Room.find(n + 1)
+  messages = room.messages.where(user_id: current_user.id)
+
+  Notification.create!(
+    visitor_id: current_user.id,
+    visited_id: other_user.id,
+    post_id: post.id,
+    comment_id: comments[0].id,
+    action: 'comment',
+    checked: 0,
+  )
+
+  Notification.create!(
+    visitor_id: current_user.id,
+    visited_id: other_user.id,
+    post_id: post.id,
+    action: 'favorite',
+    checked: 0,
+  )
+
+  Notification.create!(
+    visitor_id: current_user.id,
+    visited_id: other_user.id,
+    action: 'follow',
+    checked: 0,
+  )
+
+  Notification.create!(
+    visitor_id: current_user.id,
+    visited_id: other_user.id,
+    room_id: room.id,
+    message_id: messages[0].id,
+    action: 'message',
+    checked: 0,
+  )
+end

--- a/back/db/seeds/development/relationships.rb
+++ b/back/db/seeds/development/relationships.rb
@@ -1,6 +1,9 @@
-4.times do |n|
+5.times do |n|
+  current_user = User.find(n + 1)
+  other_user = User.find(n + 2 > 5 ? 1 : n + 2)
+
   Relationship.create!(
-    following_id: n + 1,
-    follower_id: n + 2
+    following_id: current_user.id,
+    follower_id: other_user.id,
   )
 end

--- a/back/db/seeds/development/rooms.rb
+++ b/back/db/seeds/development/rooms.rb
@@ -1,41 +1,39 @@
-Room.create! 
-@room = Room.find(1)
+5.times do |n|
+  current_user = User.find(n + 1)
+  other_user = User.find(n + 2 > 5 ? 1 : n + 2)
+  Room.create!
+  room = Room.find(n + 1)
 
-@room.entries.create! ([
-  {
-    id: 1,
-    user_id: 1,
-    room_id: 1,
-  },
-  {
-    id: 2,
-    user_id: 5,
-    room_id: 1,
-  }
-])
-@room.messages.create! ([
-  {
-    id: 1,
-    user_id: 1,
-    room_id: 1,
-    content: "こんにちはsatoです"
-  },
-  {
-    id: 2,
-    user_id: 5,
-    room_id: 1,
-    content: "初めまして鈴木です"
-  },
-  {
-    id: 3,
-    user_id: 1,
-    room_id: 1,
-    content: "これはsatoのテストメッセージです"
-  },
-  {
-    id: 4,
-    user_id: 5,
-    room_id: 1,
-    content: "鈴木のテストメッセージです"
-  },
-])
+  room.entries.create! ([
+    {
+      user_id: current_user.id,
+      room_id: room.id,
+    },
+    {
+      user_id: other_user.id,
+      room_id: room.id,
+    }
+  ])
+  room.messages.create! ([
+    {
+      user_id: current_user.id,
+      room_id: room.id,
+      content: "こんにちは#{current_user.nickname}です"
+    },
+    {
+      user_id: other_user.id,
+      room_id: room.id,
+      content: "初めまして#{other_user.nickname}です"
+    },
+    {
+      user_id: current_user.id,
+      room_id: room.id,
+      content: "これは#{current_user.nickname}のテストメッセージです"
+    },
+    {
+      user_id: other_user.id,
+      room_id: room.id,
+      content: "#{other_user.nickname}のテストメッセージです"
+    },
+  ])
+end

--- a/back/spec/models/notification_spec.rb
+++ b/back/spec/models/notification_spec.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id         :bigint           not null, primary key
+#  action     :string(255)      default(""), not null
+#  checked    :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  comment_id :integer
+#  message_id :integer
+#  post_id    :integer
+#  room_id    :integer
+#  visited_id :integer          not null
+#  visitor_id :integer          not null
+#
+# Indexes
+#
+#  index_notifications_on_comment_id  (comment_id)
+#  index_notifications_on_post_id     (post_id)
+#  index_notifications_on_visited_id  (visited_id)
+#  index_notifications_on_visitor_id  (visitor_id)
+#
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/back/spec/requests/api/v1/user/notifications_spec.rb
+++ b/back/spec/requests/api/v1/user/notifications_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::User::Notifications", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/front/front-app/src/components/organisms/layout/Header.jsx
+++ b/front/front-app/src/components/organisms/layout/Header.jsx
@@ -5,13 +5,14 @@ import {push} from 'connected-react-router';
 import MenuIcon from '@material-ui/icons/Menu';
 import { useDisclosure, Select } from "@chakra-ui/react"
 import { Link } from '@chakra-ui/react';
+import { useLocation } from 'react-router';
 
 import {MenuDrawer} from '../../molecules/MenuDrawer';
 import { getTags } from '../../../reducks/tags/operations';
 import SearchInputForm from '../../molecules/SearchInputForm';
 import useReturnTop from '../../../hooks/useReturnTop';
 import { nowLoadingAction } from '../../../reducks/loading/actions';
-import { useLocation } from 'react-router';
+import NotificationLink from '../notification/NotificationLink';
 
 export const Header = ()=> {
   const dispatch =  useDispatch();
@@ -102,20 +103,33 @@ export const Header = ()=> {
               toSearchResult={toSearchResult}
             />
           </Flex>
-          <Flex display={{base: "none", md: "flex"}} >
-            <Select placeholder="Tag Search" mr="2" bg="white" onChange={onChangeTagSearch}>
-            {
-             tagOptions.map(tagOption => (
-               <option key={tagOption.id} value={tagOption.value} >{tagOption.label}</option>
-             ))
-           }
-            </Select>
-          </ Flex >  
-          <Flex display={{base: "flex", md: "none"}}>
+          <Flex>
+            <Flex display={{base: "none", md: "flex"}}>
+              <Select placeholder="Tag Search" mr="2" bg="white" onChange={onChangeTagSearch}>
+              {
+                tagOptions.map(tagOption => (
+                  <option key={tagOption.id} value={tagOption.value} >{tagOption.label}</option>
+                  ))
+                }
+              </Select>
+            </Flex>
+            <Flex
+              mt="auto"
+              mb="auto"
+              ml="2"
+              mr="2"
+            >
+              {/* <Link onClick={onOpen}>
+                <NotificationsIcon  style={{color: 'white'}}/>
+              </Link> */}
+              <NotificationLink />
+            </Flex>
+            <Flex display={{base: "flex", md: "none"}}>
             <Link onClick={onOpen}>
-              <MenuIcon />
+              <MenuIcon style={{color: 'white'}}/>
             </Link>
           </Flex>
+          </ Flex >
         </Flex>
       </Flex>
       <MenuDrawer 

--- a/front/front-app/src/components/organisms/layout/Header.jsx
+++ b/front/front-app/src/components/organisms/layout/Header.jsx
@@ -119,9 +119,6 @@ export const Header = ()=> {
               ml="2"
               mr="2"
             >
-              {/* <Link onClick={onOpen}>
-                <NotificationsIcon  style={{color: 'white'}}/>
-              </Link> */}
               <NotificationLink />
             </Flex>
             <Flex display={{base: "flex", md: "none"}}>

--- a/front/front-app/src/components/organisms/notification/NotificationCard.jsx
+++ b/front/front-app/src/components/organisms/notification/NotificationCard.jsx
@@ -1,0 +1,102 @@
+import { useDispatch } from "react-redux";
+import { push } from "connected-react-router";
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+import { DefaultFlex, DefaultText, DefaultUserIconImage } from "../../../assets/style/chakraStyles";
+import defaultUserIcon from "../../../assets/img/defaultUserIcon.jpeg"
+import { useCallback } from "react";
+import { Box, Flex, Link } from "@chakra-ui/react";
+import useReturnTop from "../../../hooks/useReturnTop";
+import { deleteModalNotification, deletePageNotification } from "../../../reducks/notifications/operations";
+
+export const NotificationCard = (props) => {
+  const { notification, onClose, modal, setSumPage, queryPage } = props;
+  const returnTop = useReturnTop()
+  const dispatach = useDispatch()
+  const { id, action, icon, nickname, post_id, room_id, visitor_id, created_at} = notification
+
+  const toUser = useCallback(()=> {
+    dispatach(push(`/users/${visitor_id}`))
+    returnTop()
+    if(modal) {
+      onClose()
+    }
+  },[dispatach, onClose, returnTop, visitor_id, modal])
+
+  const toPost = useCallback(()=> {
+    dispatach(push(`/posts/show/${post_id}`))
+    returnTop()
+    if(modal) {
+      onClose()
+    }
+  },[dispatach, onClose, post_id, returnTop, modal])
+
+  const toRoom = useCallback(()=> {
+    dispatach(push(`/room/${room_id}`))
+    returnTop()
+    if(modal) {
+      onClose()
+    }
+  },[dispatach, onClose, room_id, returnTop, modal])
+
+  const onClickDeleteNotification = useCallback(()=> {
+    if(modal) {
+      dispatach(deleteModalNotification(id))
+    } else {
+      dispatach(deletePageNotification(id, setSumPage, queryPage))
+    }
+  },[dispatach, modal, id, setSumPage, queryPage])
+
+
+  const notificationMessage = useCallback(()=> {
+    switch(action) {
+      case 'favorite': return(
+        <Link onClick={toPost}>{nickname}さんがあなたの投稿に高評価しました</Link>
+      )
+      case 'comment' : return(
+        <Link onClick={toPost}>{nickname}さんがあなたの投稿にコメントをしました</Link>
+      )  
+      case 'follow' : return(
+        <Link onClick={toUser}>{nickname}さんがあなたをフォローしました</Link>
+      )
+      case 'message' : return(
+        <Link onClick={toRoom}>{nickname}さんからメッセージがあります</Link>
+      )
+      default:
+        <DefaultText>通知はありません</DefaultText>
+    }
+  },[action, nickname, toPost, toUser, toRoom])
+
+  return(
+    <DefaultFlex
+      backgroundColor="gray.100"
+      mb="2"
+    >
+      <DefaultUserIconImage 
+        src={icon.url? icon.url : defaultUserIcon}
+        boxSize={{ base: "20px", md: "30px" }}
+        onClick={toUser}
+        cursor="pointer"
+        mr="2"
+      />
+      <Box>
+        <DefaultText>
+          {notificationMessage()}
+        </DefaultText>
+        <DefaultText
+          fontSize="5px"
+        >
+          {created_at}
+        </DefaultText>
+      </Box>
+      <Flex 
+      ml="auto"
+      cursor="pointer"
+      onClick={onClickDeleteNotification}
+      >
+        <HighlightOffIcon/>
+      </Flex>
+    </DefaultFlex>
+  )
+}
+
+export default NotificationCard;

--- a/front/front-app/src/components/organisms/notification/NotificationCard.jsx
+++ b/front/front-app/src/components/organisms/notification/NotificationCard.jsx
@@ -14,6 +14,7 @@ export const NotificationCard = (props) => {
   const dispatach = useDispatch()
   const { id, action, icon, nickname, post_id, room_id, visitor_id, created_at} = notification
 
+  // 通知一覧画面とモーダル画面のうち、モーダル画面上のNotificationCardのみonCloseを実行
   const toUser = useCallback(()=> {
     dispatach(push(`/users/${visitor_id}`))
     returnTop()
@@ -38,6 +39,7 @@ export const NotificationCard = (props) => {
     }
   },[dispatach, onClose, room_id, returnTop, modal])
 
+  // ページネーションの関係上、モーダル画面と通知一覧画面では取得するデータを切り替える
   const onClickDeleteNotification = useCallback(()=> {
     if(modal) {
       dispatach(deleteModalNotification(id))

--- a/front/front-app/src/components/organisms/notification/NotificationLink.jsx
+++ b/front/front-app/src/components/organisms/notification/NotificationLink.jsx
@@ -1,0 +1,70 @@
+import { Link } from "@chakra-ui/react";
+import NotificationsIcon from '@material-ui/icons/Notifications';
+import { useDisclosure } from "@chakra-ui/react"
+import NotificationModal from "./NotificationModal";
+import NotificationImportantIcon from '@material-ui/icons/NotificationImportant';
+import { useCallback, useEffect, useState } from "react";
+import axios from "axios";
+import { getModalNotifications } from "../../../reducks/notifications/operations";
+import { useDispatch, useSelector } from "react-redux";
+
+export const NotificationLink = () => {
+  const {isOpen, onOpen, onClose} = useDisclosure()
+  const dispatch = useDispatch()
+  const [alert, setAlert] = useState(false)
+
+  const uncheckedNotifications = useCallback((queryPage, setSumPage)=> {
+    axios
+      .get(
+        "http://localhost:3001/api/v1/user/notifications/unchecked_notifications",
+        
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        setAlert(response.data)
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+  },[])
+
+  useEffect(()=> {
+    uncheckedNotifications()
+  },[uncheckedNotifications])
+
+  const onClickNotifications = useCallback(()=> {
+    onOpen()
+    dispatch(getModalNotifications())
+  },[onOpen, dispatch])
+
+  const notifications = useSelector((state)=> state.notifications.list)
+
+  const onClickCheckNotifications = useCallback(()=> {
+    uncheckedNotifications()
+    onClose()
+  },[onClose, uncheckedNotifications])
+
+
+  return(
+    <>
+      <Link onClick={onClickNotifications}>
+        {
+          alert ? (
+              <NotificationImportantIcon style={{color: 'blue'}}/>
+            ) : (
+              <NotificationsIcon  style={{color: 'white'}}/>
+            )
+        }
+      </Link>
+      <NotificationModal 
+        onClose={onClickCheckNotifications} 
+        isOpen={isOpen}
+        notifications={notifications}
+      />
+    </>
+  )
+}
+
+export default NotificationLink;

--- a/front/front-app/src/components/organisms/notification/NotificationLink.jsx
+++ b/front/front-app/src/components/organisms/notification/NotificationLink.jsx
@@ -13,6 +13,7 @@ export const NotificationLink = () => {
   const dispatch = useDispatch()
   const [alert, setAlert] = useState(false)
 
+  // 未確認の通知があるか確認
   const uncheckedNotifications = useCallback((queryPage, setSumPage)=> {
     axios
       .get(
@@ -34,6 +35,7 @@ export const NotificationLink = () => {
     uncheckedNotifications()
   },[uncheckedNotifications])
 
+  // モーダルを閉じつつ、再度、未確認の通知が無いか確認
   const onClickNotifications = useCallback(()=> {
     onOpen()
     dispatch(getModalNotifications())

--- a/front/front-app/src/components/organisms/notification/NotificationModal.jsx
+++ b/front/front-app/src/components/organisms/notification/NotificationModal.jsx
@@ -1,0 +1,68 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Stack,
+  Box,
+  Link,
+} from "@chakra-ui/react"
+import { push } from "connected-react-router";
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+import useReturnTop from "../../../hooks/useReturnTop";
+import NotificationCard from "./NotificationCard";
+
+export const NotificationModal = (props)=> {
+  const {onClose, isOpen, notifications} = props;
+  const returnTop = useReturnTop()
+  const dispatch = useDispatch()
+  const modal = true
+
+  const toNotifications = useCallback(()=> {
+    dispatch(push('/notifications'))
+    returnTop()
+    onClose()
+  },[dispatch, returnTop, onClose])
+
+  return(
+    <Modal         
+      onClose={onClose} 
+      isOpen={isOpen}
+    >
+      <ModalOverlay />
+      <ModalContent
+        minW={{base: "xs", md: "xl"}}
+      >
+        <ModalHeader>通知一覧</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Stack spacing="2">
+            {
+              notifications ? (
+                <Box>
+                  {
+                    notifications.map(notification => (
+                      <NotificationCard key={notification.id} notification={notification} onClose={onClose} modal={modal}/>
+                    ))
+                  }
+                </Box>
+              ) : null
+            }
+            <Link
+            textAlign="center"
+            fontSize={{base: 'sm', md: 'lg'}}
+            onClick={toNotifications}
+            >
+              通知一覧へ
+            </Link>
+          </Stack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default NotificationModal;

--- a/front/front-app/src/components/organisms/notification/NotificationModal.jsx
+++ b/front/front-app/src/components/organisms/notification/NotificationModal.jsx
@@ -45,7 +45,12 @@ export const NotificationModal = (props)=> {
                 <Box>
                   {
                     notifications.map(notification => (
-                      <NotificationCard key={notification.id} notification={notification} onClose={onClose} modal={modal}/>
+                      <NotificationCard 
+                        key={notification.id} 
+                        notification={notification} 
+                        onClose={onClose} 
+                        modal={modal}
+                      />
                     ))
                   }
                 </Box>

--- a/front/front-app/src/components/pages/mypage/Notifications.jsx
+++ b/front/front-app/src/components/pages/mypage/Notifications.jsx
@@ -1,0 +1,88 @@
+import { Center, Flex, Spinner } from "@chakra-ui/react";
+import { push } from "connected-react-router";
+import { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { DefaultFlex, DefaultTitleText } from "../../../assets/style/chakraStyles";
+import useLoadingState from "../../../hooks/useLoadingState";
+import usePagination from "../../../hooks/usePagination";
+import useReturnTop from "../../../hooks/useReturnTop";
+import { deleteAllPageNotification, getPageNotifications } from "../../../reducks/notifications/operations";
+import DeleteButton from "../../atoms/button/DeleteButton";
+import DefaultPagination from "../../molecules/DefaultPagination";
+import NotificationCard from "../../organisms/notification/NotificationCard";
+
+export const Notifications = () => {
+  const dispatch = useDispatch()
+  const {sumPage, setSumPage, queryPage} = usePagination()
+  const loadingState = useLoadingState()
+  const returnTop = useReturnTop()
+  const modal = false
+
+  useEffect(()=> {
+    dispatch(getPageNotifications(setSumPage, queryPage))
+  },[dispatch, setSumPage, queryPage])
+
+  const notifications = useSelector((state)=> state.notifications.list)
+
+  const changeCurrentPage = useCallback((e, page) =>{
+    dispatch(push(`/notifications/?page=${page}`))
+    returnTop()
+  },[dispatch, returnTop])
+
+  const onClickdeleteAllNotifications = useCallback(()=> {
+    dispatch(deleteAllPageNotification(setSumPage))
+  },[dispatch, setSumPage])
+
+  return(
+    <>
+      <DefaultFlex mb="4">
+        <DefaultTitleText ml="auto" mr="auto">通知一覧</DefaultTitleText>
+        {
+          notifications.length > 0 && (
+            <DeleteButton
+              onClick={onClickdeleteAllNotifications}
+            >
+              一括削除
+            </DeleteButton>
+          )
+        }
+      </DefaultFlex>
+      { 
+      loadingState? (
+        <Center  h="100vh" w={{base: "50vh", md: "100vh"}}>
+          <Spinner/>
+        </Center>
+      ): (
+        <>
+          {
+            notifications.length > 0 && (
+              <DefaultFlex flexDirection="column">
+                {
+                  notifications.map(notification => (
+                    <NotificationCard 
+                      key={notification.id} 
+                      notification={notification} 
+                      modal={modal} 
+                      setSumPage={setSumPage}
+                      queryPage={queryPage}
+                    />
+                  ))
+                }
+                <Flex mr="auto" ml="auto" mb="4">
+                  <DefaultPagination 
+                    count={sumPage}
+                    onChange={changeCurrentPage}
+                    page={queryPage}
+                  />
+                </Flex>
+              </DefaultFlex>
+            )
+          }
+        </>
+      )
+      }
+    </>
+  )
+}
+
+export default Notifications;

--- a/front/front-app/src/reducks/notifications/actions.js
+++ b/front/front-app/src/reducks/notifications/actions.js
@@ -1,0 +1,23 @@
+export const GET_NOTIFICATIONS = "GET_NOTIFICATIONS";
+export const getNotificationsAction = (notifications) => {
+  return {
+    type: GET_NOTIFICATIONS,
+    payload: notifications,
+  };
+};
+
+export const DELETE_NOTIFICATION = "DELETE_NOTIFICATION";
+export const deleteNotificationAction = (notifications) => {
+  return {
+    type: DELETE_NOTIFICATION,
+    payload: notifications,
+  };
+};
+
+export const DELETE_ALL_NOTIFICATIONS = "DELETE_ALL_NOTIFICATIONS";
+export const deleteAllNotificationActions = (notifications) => {
+  return {
+    type: DELETE_ALL_NOTIFICATIONS,
+    payload: notifications,
+  };
+};

--- a/front/front-app/src/reducks/notifications/operations.js
+++ b/front/front-app/src/reducks/notifications/operations.js
@@ -1,0 +1,117 @@
+import axios from "axios";
+import { nowLoadingAction } from "../loading/actions";
+import {
+  deleteAllNotificationActions,
+  deleteNotificationAction,
+  getNotificationsAction,
+} from "./actions";
+
+export const getModalNotifications = () => {
+  return async (dispatch) => {
+    axios
+      .get(
+        "http://localhost:3001/api/v1/user/notifications",
+
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        dispatch(getNotificationsAction(response.data.notifications));
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      });
+  };
+};
+
+export const getPageNotifications = (setSumPage, queryPage) => {
+  return async (dispatch) => {
+    dispatch(nowLoadingAction(true));
+    axios
+      .get(
+        `http://localhost:3001/api/v1/user/notifications/?page=${queryPage}`,
+
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        dispatch(getNotificationsAction(response.data.notifications));
+        setSumPage(response.data.page_length);
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+      .finally(() => {
+        setTimeout(() => {
+          dispatch(nowLoadingAction(false));
+        }, 800);
+      });
+  };
+};
+
+export const deleteModalNotification = (id) => {
+  return async (dispatch) => {
+    axios
+      .delete(
+        `http://localhost:3001/api/v1/user/notifications/${id}`,
+
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        dispatch(deleteNotificationAction(response.data.notifications));
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      });
+  };
+};
+
+export const deletePageNotification = (id, setSumPage, queryPage) => {
+  return async (dispatch) => {
+    axios
+      .delete(
+        `http://localhost:3001/api/v1/user/notifications/${id}/?page=${queryPage}`,
+
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        dispatch(deleteNotificationAction(response.data.notifications));
+        setSumPage(response.data.page_length);
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      });
+  };
+};
+
+export const deleteAllPageNotification = (setSumPage) => {
+  return async (dispatch) => {
+    dispatch(nowLoadingAction(true));
+    axios
+      .delete(
+        "http://localhost:3001/api/v1/user/notifications/destroy_all",
+
+        {
+          withCredentials: true,
+        }
+      )
+      .then((response) => {
+        dispatch(deleteAllNotificationActions([]));
+        setSumPage(1);
+      })
+      .catch((error) => {
+        console.log("error:", error);
+      })
+      .finally(() => {
+        setTimeout(() => {
+          dispatch(nowLoadingAction(false));
+        }, 800);
+      });
+  };
+};

--- a/front/front-app/src/reducks/notifications/reducers.js
+++ b/front/front-app/src/reducks/notifications/reducers.js
@@ -1,0 +1,27 @@
+import * as Actions from "./actions";
+import initialState from "../store/initialState";
+
+export const NotificationsReducer = (
+  state = initialState.notifications,
+  action
+) => {
+  switch (action.type) {
+    case Actions.GET_NOTIFICATIONS:
+      return {
+        ...state,
+        list: [...action.payload],
+      };
+    case Actions.DELETE_NOTIFICATION:
+      return {
+        ...state,
+        list: [...action.payload],
+      };
+    case Actions.DELETE_ALL_NOTIFICATIONS:
+      return {
+        ...state,
+        list: [...action.payload],
+      };
+    default:
+      return state;
+  }
+};

--- a/front/front-app/src/reducks/store/initialState.js
+++ b/front/front-app/src/reducks/store/initialState.js
@@ -46,6 +46,10 @@ const initialState = {
       list: [],
     },
   },
+
+  notifications: {
+    list: [],
+  },
 };
 
 export default initialState;

--- a/front/front-app/src/reducks/store/store.js
+++ b/front/front-app/src/reducks/store/store.js
@@ -15,6 +15,7 @@ import { TagsReducer } from "../tags/reducers";
 import { FavoriteReducer } from "../favorite/reducers";
 import { FollowReducer } from "../follow/reducers";
 import { RoomReducer } from "../rooms/reducers";
+import { NotificationsReducer } from "../notifications/reducers";
 
 export default function createState(history) {
   return reduxCreateStore(
@@ -29,6 +30,7 @@ export default function createState(history) {
       favorite: FavoriteReducer,
       follow: FollowReducer,
       room: RoomReducer,
+      notifications: NotificationsReducer,
     }),
     applyMiddleware(routerMiddleware(history), thunk)
   );

--- a/front/front-app/src/router/Router.jsx
+++ b/front/front-app/src/router/Router.jsx
@@ -18,6 +18,7 @@ import Followers from '../components/pages/mypage/Followers'
 import SearchResult from '../components/pages/SearchResult'
 import Room from '../components/pages/Room'
 import Rooms from '../components/pages/mypage/Rooms'
+import Notifications from '../components/pages/mypage/Notifications'
 
 export const Router = () => {
   return(
@@ -37,6 +38,7 @@ export const Router = () => {
           <Route path={"/mypage/:id/followers"} component={Followers} />
           <Route path={"/mypage/:id/favoritePosts"} component={FavoritePosts} />
           <Route path={"/mypage/:id/rooms"} component={Rooms} />
+          <Route path={"/notifications"} component={Notifications} />
           <Route path={"/searchResult"} component={SearchResult} />
           <Route path={"/room/:id"} component={Room} />
           <Route path={"/users/:id"} component={UsersInfo} />


### PR DESCRIPTION
## 通知機能

### 変更詳細
- 他のユーザーからコメント、高評価、フォロー、メッセージあった場合に通知が来る
- 通知はヘッダー、通知一覧画面('/notifications')から確認可能
- 未確認の通知が存在する場合、ヘッダーの通知アイコンが青色になる
- ヘッダーの通知アイコンをクリックするとモーダルが開き、最新10件の通知を確認できる
- コメント・高評価の通知をクリックすると該当記事へ遷移、フォロー通知をクリックするとユーザー詳細ページ、メッセージ通知をクリックするとチャットルームへ遷移する
- ヘッダーモーダルの下部に「通知一覧へ」リンクがあり、過去のすべての通知を確認できる通知一覧画面へ遷移
- 各通知には削除アイコンが横に添えられており、クリックすると個別削除可能
- 通知一覧画面の画面上部に一括削除ボタンが設置されており、すべての通知を削除可能

### 動作環境

確認される不具合はございません。

※今回のプルリクエスト以前に、こちら側でリクエストを出さずにマージした変更内容が
ございます(主な変更内容がバックエンドのため)。
一旦、現在の`GitHub`のマスターブランチを取り込んで頂いてから今回の変更分を
ご確認頂ければと存じます。

データベースの追加と初期データの追加、修正を行いましたので下記のコマンドの実行を宜しくお願い致します。

```
docker-compose run back db:migrate
docker-compose run back db:reset
```


### 主な変更箇所
- `reducks`以下に新たに`notifications`に関連するフォルダを新規追加
- `conponents/organisms`の`notification`フォルダを追加して`view`に関連するファイルを追加
- `components/pages/mypage`に通知一覧画面の`Notifications`ファイルを追加

###  特にレビューして欲しいところ
基本的に今までの知識で実装ができましたが、`components/orfanisms/notification/NotificationCard.jsx`
において、`NotificationCard`がモーダル上で表示されているのか通知一覧画面上('/notifications')で表示されているかで
ページ遷移時や通知削除時の処理を切り分ける試みをしております。

### 保留していること
特に無し

### その他
変更ファイルは30ですが、Reactで主要な変更、追加ファイルは7~9ファイルになると思います。
今回も特に急ぎではございませんので、お時間がございますタイミングで
レビューを宜しくお願い致します。


![A56FEF33-1C16-470D-BCC4-AE642DFB6FB6_4_5005_c](https://user-images.githubusercontent.com/66899822/128002222-a5764a06-dafa-495e-9d04-59cce47266ba.jpeg)
<img width="569" alt="3E7C3F84-16A5-448C-A48A-D524E14FE761" src="https://user-images.githubusercontent.com/66899822/128002257-468eb0b1-73b8-4592-9ad3-41de4897c928.png">
<img width="743" alt="EC9D00F2-0624-42FE-B2EB-8D02B79D8ADD" src="https://user-images.githubusercontent.com/66899822/128002293-1a6fac2a-8eb7-4096-a060-84443514f0f2.png">
